### PR TITLE
fix: add istio-k8s to integration tests

### DIFF
--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -28,7 +28,7 @@ APP_NAME = METADATA["name"]
 
 
 @dataclass
-class CharmDeploymentConfdiguration:
+class CharmDeploymentConfiguration:
     entity_url: str  # aka charm name or local path to charm
     application_name: str
     channel: str
@@ -36,7 +36,7 @@ class CharmDeploymentConfdiguration:
     config: Optional[dict] = None
 
 
-ISTIO_K8S = CharmDeploymentConfdiguration(
+ISTIO_K8S = CharmDeploymentConfiguration(
     entity_url="istio-k8s", application_name="istio-k8s", channel="latest/edge", trust=True
 )
 

--- a/tests/integration/testers/ipa/charmcraft.yaml
+++ b/tests/integration/testers/ipa/charmcraft.yaml
@@ -14,3 +14,5 @@ parts:
       - ops
     build-packages:
       - git
+      - cargo
+      - rustc


### PR DESCRIPTION
Adds istio-k8s dependency to integration tests, as well as fixes some minor test bugs.

This PR is based on #8 - marge after #8

### Testing notes:
* integration CI should pass.  If passing, this should be fully validated

