### PR TITLE
ingress integration does not pass HTTPS ingress url through the integration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -588,7 +588,8 @@ class IstioIngressCharm(CharmBase):
 
     def _generate_external_url(self, prefix: str) -> str:
         """Generate external URL for the ingress."""
-        return f"http://{self._external_host}{prefix}"
+        scheme = "https" if self._construct_gateway_tls_secret() is not None else "http"
+        return f"{scheme}://{self._external_host}{prefix}"
 
     @property
     def _external_host(self) -> Optional[str]:


### PR DESCRIPTION
## Issue
Fixes #24 


## Solution
Instead of generating a hard-coded scheme, check if we have a valid cert relation before specifying whether scheme is `HTTP`/`HTTPS` 