### PR TITLE
Create an Authorization Policy for any ingress relation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -90,9 +90,9 @@ INGRESS_RESOURCE_TYPES = {
     RESOURCE_TYPES["HTTPRoute"],
 }
 AUTHORIZATION_POLICY_RESOURCE_TYPES = {RESOURCE_TYPES["AuthorizationPolicy"]}
-GATEWAY_LABEL = "istio-gateway"
-INGRESS_LABEL = "istio-ingress"
-AUTHORIZATION_POLICY_LABEL = "istio-ingress-authorization-policy"
+GATEWAY_SCOPE = "istio-gateway"
+INGRESS_SCOPE = "istio-ingress"
+AUTHORIZATION_POLICY_SCOPE = "istio-ingress-authorization-policy"
 
 
 class DataValidationError(RuntimeError):
@@ -222,7 +222,7 @@ class IstioIngressCharm(CharmBase):
     def _get_gateway_resource_manager(self):
         return KubernetesResourceManager(
             labels=create_charm_default_labels(
-                self.app.name, self.model.name, scope=GATEWAY_LABEL
+                self.app.name, self.model.name, scope=GATEWAY_SCOPE
             ),
             resource_types=GATEWAY_RESOURCE_TYPES,  # pyright: ignore
             lightkube_client=self.lightkube_client,
@@ -232,7 +232,7 @@ class IstioIngressCharm(CharmBase):
     def _get_ingress_resource_manager(self):
         return KubernetesResourceManager(
             labels=create_charm_default_labels(
-                self.app.name, self.model.name, scope=INGRESS_LABEL
+                self.app.name, self.model.name, scope=INGRESS_SCOPE
             ),
             resource_types=INGRESS_RESOURCE_TYPES,  # pyright: ignore
             lightkube_client=self.lightkube_client,
@@ -242,7 +242,7 @@ class IstioIngressCharm(CharmBase):
     def _get_authorization_policy_resource_manager(self):
         return KubernetesResourceManager(
             labels=create_charm_default_labels(
-                self.app.name, self.model.name, scope=AUTHORIZATION_POLICY_LABEL
+                self.app.name, self.model.name, scope=AUTHORIZATION_POLICY_SCOPE
             ),
             resource_types=AUTHORIZATION_POLICY_RESOURCE_TYPES,  # pyright: ignore
             lightkube_client=self.lightkube_client,
@@ -471,7 +471,7 @@ class IstioIngressCharm(CharmBase):
 
         auth_policy = AuthorizationPolicyResource(
             metadata=Metadata(
-                name=data.app.name + "-" + self.app.name + "-l4-policy",
+                name=data.app.name + "-" + self.app.name + "-" + data.app.model + "-l4",
                 namespace=data.app.model,
             ),
             spec=AuthorizationPolicySpec(

--- a/src/models.py
+++ b/src/models.py
@@ -178,15 +178,6 @@ class Action(str, Enum):
     allow = "ALLOW"
 
 
-class PolicyTargetReference(BaseModel):
-    """PolicyTargetReference defines the target of the policy."""
-
-    group: str
-    kind: str
-    name: str
-    namespace: Optional[str] = None
-
-
 class WorkloadSelector(BaseModel):
     """WorkloadSelector defines the selector for the policy."""
 
@@ -232,8 +223,6 @@ class AuthorizationPolicySpec(BaseModel):
     """AuthorizationPolicySpec defines the spec of an Istio AuthorizationPolicy Kubernetes resource."""
 
     action: Action = Action.allow
-    # TODO: Do we need L7 ingress policies?
-    # targetRefs: List[PolicyTargetReference]
     rules: List[AuthRule]
     selector: WorkloadSelector
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -20,6 +20,12 @@ RESOURCE_TYPES = {
     "HTTPRoute": create_namespaced_resource(
         "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
     ),
+    "AuthorizationPolicy": create_namespaced_resource(
+        "security.istio.io",
+        "v1",
+        "AuthorizationPolicy",
+        "authorizationpolicies",
+    ),
 }
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -107,6 +107,29 @@ async def get_route_spec(ops_test: OpsTest, route_name: str) -> Optional[Dict[st
         return None
 
 
+async def get_auth_policy_spec(ops_test: OpsTest, policy_name: str) -> Optional[Dict[str, Any]]:
+    """Retrieve and check the spec of the AuthorizationPolicy resource.
+
+    Args:
+        ops_test: pytest-operator plugin
+        policy_name: Name of the AuthorizationPolicy resource.
+
+    Returns:
+        A dictionary representing the spec of the policy, or None if not found.
+    """
+    model = ops_test.model.info
+    try:
+        c = lightkube.Client()
+        policy = c.get(
+            RESOURCE_TYPES["AuthorizationPolicy"], namespace=model.name, name=policy_name
+        )
+        return policy.spec
+
+    except Exception as e:
+        logger.error("Error retrieving AuthorizationPolicy condition: %s", e, exc_info=1)
+        return None
+
+
 async def get_route_condition(ops_test: OpsTest, route_name: str) -> Optional[Dict[str, Any]]:
     """Retrieve and check the condition from the HTTPRoute resource.
 

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -122,7 +122,7 @@ async def test_ipa_charm_has_ingress(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_auth_policy_validity(ops_test: OpsTest):
-    policy_name = "ipa-tester-k8s-istio-ingress-k8s-l4-policy"
+    policy_name = f"{IPA_TESTER}-{APP_NAME}-{ops_test.model_full_name}-l4"
 
     # Retrieve the AuthorizationPolicy spec
     policy_spec = await get_auth_policy_spec(ops_test, policy_name)

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -122,7 +122,7 @@ async def test_ipa_charm_has_ingress(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_auth_policy_validity(ops_test: OpsTest):
-    policy_name = f"{IPA_TESTER}-{APP_NAME}-{ops_test.model_full_name}-l4"
+    policy_name = f"{IPA_TESTER}-{APP_NAME}-{ops_test.model.name}-l4"
 
     # Retrieve the AuthorizationPolicy spec
     policy_spec = await get_auth_policy_spec(ops_test, policy_name)
@@ -150,7 +150,7 @@ async def test_auth_policy_validity(ops_test: OpsTest):
     principals = from_rules[0]["source"].get("principals", [])
     assert len(principals) == 1, "Expected exactly one principal in the 'source' field."
     assert (
-        principals[0] == f"cluster.local/ns/{ops_test.model_full_name}/sa/istio-ingress-k8s-istio"
+        principals[0] == f"cluster.local/ns/{ops_test.model.name}/sa/istio-ingress-k8s-istio"
     ), "Principal does not match expected format."
 
     # Validate 'selector' field

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -14,6 +14,7 @@ from conftest import (
 )
 from helpers import (
     dequote,
+    get_auth_policy_spec,
     get_k8s_service_address,
     get_listener_condition,
     get_listener_spec,
@@ -117,6 +118,49 @@ async def test_ipa_charm_has_ingress(ops_test: OpsTest):
     istio_ingress_address = await get_k8s_service_address(ops_test, "istio-ingress-k8s-istio")
 
     assert url == f"http://{istio_ingress_address}/{model}-ipa-tester"
+
+
+@pytest.mark.abort_on_fail
+async def test_auth_policy_validity(ops_test: OpsTest):
+    policy_name = "ipa-tester-k8s-istio-ingress-k8s-l4-policy"
+
+    # Retrieve the AuthorizationPolicy spec
+    policy_spec = await get_auth_policy_spec(ops_test, policy_name)
+
+    # Ensure the policy spec is not None
+    assert policy_spec is not None, f"AuthorizationPolicy '{policy_name}' not found."
+
+    # Validate the 'rules' structure
+    assert "rules" in policy_spec, "'rules' field is missing in the AuthorizationPolicy spec."
+    rules = policy_spec["rules"]
+    assert len(rules) == 1, "Expected exactly one rule in AuthorizationPolicy spec."
+
+    # Validate the 'to' field inside the rule
+    to_rules = rules[0].get("to", [])
+    assert len(to_rules) == 1, "'to' field should contain exactly one operation."
+    assert "operation" in to_rules[0], "Missing 'operation' in the 'to' field."
+    assert to_rules[0]["operation"]["ports"] == [
+        "8080"
+    ], "Port mismatch in the AuthorizationPolicy."
+
+    # Validate the 'from' field inside the rule
+    from_rules = rules[0].get("from", [])
+    assert len(from_rules) == 1, "'from' field should contain exactly one source."
+    assert "source" in from_rules[0], "Missing 'source' in the 'from' field."
+    principals = from_rules[0]["source"].get("principals", [])
+    assert len(principals) == 1, "Expected exactly one principal in the 'source' field."
+    assert (
+        principals[0] == f"cluster.local/ns/{ops_test.model_full_name}/sa/istio-ingress-k8s-istio"
+    ), "Principal does not match expected format."
+
+    # Validate 'selector' field
+    assert (
+        "selector" in policy_spec
+    ), "'selector' field is missing in the AuthorizationPolicy spec."
+    match_labels = policy_spec["selector"].get("matchLabels", {})
+    assert (
+        match_labels.get("app.kubernetes.io/name") == "ipa-tester"
+    ), "AuthorizationPolicy selector does not match the expected app name."
 
 
 @pytest.mark.abort_on_fail

--- a/tests/scenario/test_ingress.py
+++ b/tests/scenario/test_ingress.py
@@ -90,6 +90,41 @@ def test_construct_httproute(
         )
 
 
+def test_construct_ingress_auth_policy(
+    istio_ingress_charm, istio_ingress_context, mock_ingress_requirer_data
+):
+    """Test that the _construct_ingress_auth_policy method constructs an Authorization Policy object correctly."""
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(),
+    ) as manager:
+        charm: IstioIngressCharm = manager.charm
+        auth_policy = charm._construct_ingress_auth_policy(
+            data=mock_ingress_requirer_data,
+        )
+
+        # Verify the AuthorizationPolicy resource
+        assert auth_policy.metadata.name == "app-name-{}-l4-policy".format(charm.app.name)
+        assert auth_policy.metadata.namespace == "app-namespace"
+
+        # Check spec rules
+        assert len(auth_policy.spec["rules"]) == 1
+        rule = auth_policy.spec["rules"][0]
+
+        # Verify `to` field
+        assert rule["to"] == [{"operation": {"ports": ["80"]}}]
+
+        # Verify `from` field (principals)
+        principals = rule["from"][0]["source"]["principals"]
+        expected_principal = f"cluster.local/ns/{charm.model.name}/sa/{charm.managed_name}"
+        assert principals == [expected_principal]
+
+        # Verify workload selector
+        assert auth_policy.spec["selector"] == {
+            "matchLabels": {"app.kubernetes.io/name": "app-name"}
+        }
+
+
 def test_construct_redirect_to_https_httproute(
     istio_ingress_charm, istio_ingress_context, mock_ingress_requirer_data
 ):
@@ -181,9 +216,13 @@ def test_sync_ingress_resources(
     istio_ingress_context,
 ):
     """Test that the _sync_ingress_resources constructs HTTP routes when TLS is not configured."""
-    mock_krm = MagicMock()
-    mock_krm_factory = MagicMock(return_value=mock_krm)
+    # Mock Kubernetes Resource Managers
+    mock_ingress_manager = MagicMock()
+    mock_auth_manager = MagicMock()
+    mock_ingress_manager_factory = MagicMock(return_value=mock_ingress_manager)
+    mock_auth_manager_factory = MagicMock(return_value=mock_auth_manager)
 
+    # Initialize charm in test scenario
     with istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(
@@ -192,19 +231,35 @@ def test_sync_ingress_resources(
         ),
     ) as manager:
         charm: IstioIngressCharm = manager.charm
-        charm._get_ingress_resource_manager = mock_krm_factory
+
+        # Patch the managers into the charm
+        charm._get_ingress_resource_manager = mock_ingress_manager_factory
+        charm._get_authorization_policy_resource_manager = mock_auth_manager_factory
+
+        # Call the method under test
         charm._sync_ingress_resources()
 
-        # Assert that we've tried to reconcile the kubernetes resources
-        charm._get_ingress_resource_manager().reconcile.assert_called_once()
+        # Assertions: Managers' reconcile methods are called once
+        mock_ingress_manager.reconcile.assert_called_once()
+        mock_auth_manager.reconcile.assert_called_once()
 
-        # Assert that _+_______________________
-        resources = charm._get_ingress_resource_manager().reconcile.call_args[0][0]
+        # Retrieve the resources passed to reconcile
+        ingress_resources = mock_ingress_manager.reconcile.call_args[0][0]
+        auth_resources = mock_auth_manager.reconcile.call_args[0][0]
 
-        assert len(resources) == n_routes_expected
-        for route in resources:
+        # Assertions: Check resource counts
+        assert len(ingress_resources) == n_routes_expected
+        assert len(auth_resources) == n_routes_expected
+
+        # Assertions: Verify each ingress resource's structure
+        for route in ingress_resources:
             assert len(route.spec["parentRefs"]) == 1
             assert route.spec["parentRefs"][0]["sectionName"] == "http"
+
+        # Assertions: Verify authorization resources
+        for auth in auth_resources:
+            assert auth.metadata.name is not None
+            assert auth.metadata.namespace is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/scenario/test_ingress.py
+++ b/tests/scenario/test_ingress.py
@@ -104,7 +104,7 @@ def test_construct_ingress_auth_policy(
         )
 
         # Verify the AuthorizationPolicy resource
-        assert auth_policy.metadata.name == "app-name-{}-l4-policy".format(charm.app.name)
+        assert auth_policy.metadata.name == f"app-name-{charm.app.name}-app-namespace-l4"
         assert auth_policy.metadata.namespace == "app-namespace"
 
         # Check spec rules


### PR DESCRIPTION
## Issue
Fixes #30 

## Solution
Create an L4 policy for each `httproute`.

## Testing Instructions

1. juju deploy istio-k8s
2. juju deploy istio-beacon with `model-on-mesh=true`
3. juju deploy istio-ingress
4. juju deploy alertmanager-k8s
5. juju relate alertmanager-k8s istio-ingress
6. An authorization policy should be created automatically and alertmanager-k8s ingress url should be reachable

## Out of PR scope
1- Generating policies for non-charmed workloads https://github.com/canonical/istio-ingress-k8s-operator/issues/32
2- Policies with multiple ports/paths for multi routes ingresses https://github.com/canonical/istio-ingress-k8s-operator/issues/23#issuecomment-2549390968

