### PR TITLE
feat: enable scaling of the charm and underlying Gateway workload

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -68,7 +68,7 @@ config:
 
 peers:
   peers:
-    interface: istio_k8s_peers
+    interface: istio_ingress_k8s_peers
 
 provides:
   ingress:

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,7 +105,6 @@ GATEWAY_SCOPE = "istio-gateway"
 INGRESS_SCOPE = "istio-ingress"
 INGRESS_AUTH_POLICY_SCOPE = "istio-ingress-authorization-policy"
 EXTZ_AUTH_POLICY_SCOPE = "external-authorizer-authorization-policy"
-HPA_SCOPE = "istio-ingress-hpa"
 
 INGRESS_CONFIG_RELATION = "istio-ingress-config"
 FORWARD_AUTH_RELATION = "forward-auth"
@@ -698,7 +697,6 @@ class IstioIngressCharm(CharmBase):
         * Update forward auth relation data with ingressed apps.
         * Request certificate inspection.
         """
-
         if not self.unit.is_leader():
             self.unit.status = ActiveStatus("Backup unit; standing by for leader takeover")
             return

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -243,7 +243,7 @@ async def test_gateway_round_robin(ops_test: OpsTest):
     envoy_ids = fetch_envoy_peer_metadata_ids(tester_url, 9)
     assert len(envoy_ids) == 3
 
-    await ops_test.model.applications[APP_NAME].scale(1)
+    await ops_test.model.applications[APP_NAME].scale(scale_change=-2)
     await ops_test.model.wait_for_idle([APP_NAME, IPA_TESTER], status="active", timeout=1000)
 
     # Retry logic to wait for K8s to update the service endpoints

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -102,7 +102,7 @@ async def test_scale(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].scale(3)
     await ops_test.model.wait_for_idle([APP_NAME], status="active", timeout=1000)
 
-    hpa = await get_hpa(ops_test, f"{APP_NAME}-istio")
+    hpa = await get_hpa(ops_test, APP_NAME)
 
     assert hpa is not None
     assert hpa.spec.minReplicas == 3

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -108,7 +108,18 @@ async def test_scale(ops_test: OpsTest):
     assert hpa is not None
     assert hpa.spec.minReplicas == 3
     assert hpa.spec.maxReplicas == 3
-    assert hpa.status.currentReplicas == 3
+
+    async def wait_for_current_replicas(expected_replicas, retries=10, delay=10):
+        for _ in range(retries):
+            hpa = await get_hpa(ops_test, APP_NAME)
+            if hpa.status.currentReplicas == expected_replicas:
+                return True
+            await asyncio.sleep(delay)
+        return False
+
+    assert await wait_for_current_replicas(
+        3
+    ), f"Expected currentReplicas to be 3, got {hpa.status.currentReplicas}"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -72,7 +72,7 @@ async def test_gateway_scaling(ops_test: OpsTest, n_units):
 
     Note: This test is stateful and will leave the deployment at a scale of 2.
     """
-    await ops_test.model.applications[APP_NAME].scale(3)
+    await ops_test.model.applications[APP_NAME].scale(n_units)
     await ops_test.model.wait_for_idle([APP_NAME], status="active", timeout=1000)
 
     hpa = await get_hpa(ops_test.model.name, APP_NAME)

--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -1,0 +1,110 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+from helpers import get_hpa
+from juju.unit import Unit
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+resources = {
+    "metrics-proxy-image": METADATA["resources"]["metrics-proxy-image"]["upstream-source"],
+}
+
+
+@dataclass
+class CharmDeploymentConfiguration:
+    entity_url: str  # aka charm name or local path to charm
+    application_name: str
+    channel: str
+    trust: bool
+    config: Optional[dict] = None
+
+
+ISTIO_K8S = CharmDeploymentConfiguration(
+    entity_url="istio-k8s", application_name="istio-k8s", channel="latest/edge", trust=True
+)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_dependencies(ops_test: OpsTest):
+    """Deploy istio as a dependency."""
+    # Deploy Istio-k8s
+    await ops_test.model.deploy(**asdict(ISTIO_K8S))
+    await ops_test.model.wait_for_idle(
+        [
+            ISTIO_K8S.application_name,
+        ],
+        status="active",
+        timeout=1000,
+    )
+
+    # Deploy ipa-tester
+    await ops_test.model.deploy(
+        ipa_tester_charm,
+        application_name=IPA_TESTER,
+        resources={"echo-server-image": "jmalloc/echo-server:v0.3.7"},
+    ),
+    await ops_test.model.wait_for_idle(
+        [
+            IPA_TESTER,
+        ],
+        status="active",
+        timeout=1000,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_deployment(ops_test: OpsTest, istio_ingress_charm):
+    await ops_test.model.deploy(
+        istio_ingress_charm, resources=resources, application_name=APP_NAME, trust=True
+    ),
+    await ops_test.model.wait_for_idle([APP_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.parametrize(
+    "n_units",
+    (
+        # Scale up from 1 to 3
+        3,
+        # Scale down to 2
+        2,
+    )
+)
+async def test_gateway_scaling(ops_test: OpsTest, n_units):
+    """Tests that, when the application is scaled, the HPA managing replicas on the Gateway is scaled too.
+
+    Note: This test is stateful and will leave the deployment at a scale of 2.
+    """
+    await ops_test.model.applications[APP_NAME].scale(3)
+    await ops_test.model.wait_for_idle([APP_NAME], status="active", timeout=1000)
+
+    hpa = await get_hpa(ops_test.model.name, APP_NAME)
+
+    assert hpa is not None
+    assert hpa.spec.minReplicas == 3
+    assert hpa.spec.maxReplicas == 3
+
+    assert await wait_for_hpa_current_replicas(
+        ops_test.model.name, APP_NAME, 3
+    ), f"Expected currentReplicas to be 3, got {hpa.status.currentReplicas}"
+
+
+async def wait_for_hpa_current_replicas(namespace, hpa_name, expected_replicas, retries=10, delay=10):
+    for _ in range(retries):
+        hpa = await get_hpa(namespace, hpa_name)
+        if hpa.status.currentReplicas == expected_replicas:
+            return True
+        await asyncio.sleep(delay)
+    return False


### PR DESCRIPTION
## Issue
Fixes #16 


## Solution
This PR adds a HorizontalPodAutoscaler that is bound to the charm and would always update the gateway's deployment replicas to match the charm's unit count
