### PR TITLE
Change HTTPRoute naming convention to avoid collisions with other ingresses in the same model

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -470,7 +470,7 @@ class IstioIngressCharm(CharmBase):
     def _construct_httproute(self, data: IngressRequirerData, prefix: str, section_name: str):
         http_route = HTTPRouteResource(
             metadata=Metadata(
-                name=data.app.name + "-" + section_name,
+                name=data.app.name + "-" + section_name + "-" + self.app.name,
                 namespace=data.app.model,
             ),
             spec=HTTPRouteResourceSpec(
@@ -587,7 +587,7 @@ class IstioIngressCharm(CharmBase):
     ):
         http_route = HTTPRouteResource(
             metadata=Metadata(
-                name=data.app.name + "-" + section_name,
+                name=data.app.name + "-" + section_name + "-" + self.app.name,
                 namespace=data.app.model,
             ),
             spec=HTTPRouteResourceSpec(

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -186,7 +186,7 @@ async def test_route_validity(
     tester_url = f"http://{istio_ingress_address}/{model}-{IPA_TESTER}"
 
     listener_condition = await get_listener_condition(ops_test, "istio-ingress-k8s")
-    route_condition = await get_route_condition(ops_test, f"{IPA_TESTER}-http")
+    route_condition = await get_route_condition(ops_test, f"{IPA_TESTER}-http-{APP_NAME}")
     listener_spec = await get_listener_spec(ops_test, "istio-ingress-k8s")
 
     assert listener_condition["attachedRoutes"] == 1


### PR DESCRIPTION
## Issue
Fixes #63 

