### PR TITLE
A working demo for Istio+Authentication integration

### DIFF
--- a/tests/manual/auth/README.md
+++ b/tests/manual/auth/README.md
@@ -1,0 +1,90 @@
+# Manual Test Guide – Auth Setup
+
+## ✅ Prerequisites
+
+Ensure the following environment is prepared before running the tests:
+
+- A **Juju controller (v3.1+)** bootstrapped on a **MicroK8s** cluster
+- **MetalLB** enabled on the MicroK8s cluster with a pool that has **at least 2 available IP addresses**
+
+### MetalLB Setup
+
+If MetalLB is **not yet enabled**, use:
+
+```bash
+sudo microk8s enable metallb:10.64.140.43-10.64.140.49
+```
+
+If MetalLB was enabled with only a single IP address, reset it using:
+
+```bash
+sudo microk8s disable metallb
+sudo microk8s enable metallb:10.64.140.43-10.64.140.49
+```
+
+> Ensure the IP range has at least 2 available IPs for the ingress charms to bind.
+
+---
+
+## 🧪 Running the Test
+
+To set up and deploy the full environment, run:
+
+```bash
+tox -e auth-setup -- --keep-models
+```
+
+This will spin up **3 Juju models**:
+
+- `istio-system`: Hosts the Istio core components.
+- `iam`: Hosts IAM-related components (Hydra, Kratos, Login UI, PostgreSQL).
+- `ingress`: Hosts:
+  - `istio-ingress-admin` & `istio-ingress-public` charms
+  - `oauth2-proxy` charm (authentication gateway)
+  - `self-signed-certificates` charm (TLS)
+  - Two `catalogue` charms:
+    - `catalogue-authed`: behind OAuth2-authenticated ingress
+    - `catalogue-unauthed`: behind unauthenticated ingress
+
+---
+
+## 👤 Create a User for Authentication
+
+Once deployment is complete, create a test user in Kratos using:
+
+```bash
+juju run -m iam kratos/0 create-admin-account email=test@example.com password=test username=admin
+```
+
+This will return:
+- A **recovery code**
+- A **link to set a new password**
+
+>  Follow the link in a browser, create a password, and complete the 2FA setup using a 2FA app like **Google Authenticator**.
+
+---
+
+## 🔍 Test the Ingress Behavior
+
+### 1. Unauthenticated Catalogue Page
+
+Visit the following URL in your browser:
+
+```
+https://<public-ingress-ip>/ingress-catalogue-unauthed
+```
+
+✅ You should reach the catalogue page **without authentication**.
+
+### 2. Authenticated Catalogue Page
+
+Now go to:
+
+```
+https://<public-ingress-ip>/ingress-catalogue-authed
+```
+
+✅ This will redirect you to the **OAuth2 login page**.
+
+- Use the credentials you set earlier (`test@example.com` + your password + 2FA code)
+- After login, you’ll be redirected to the **authenticated catalogue** page

--- a/tests/manual/auth/conftest.py
+++ b/tests/manual/auth/conftest.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import functools
+import logging
+import shutil
+import subprocess
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+class Store(defaultdict):
+    def __init__(self):
+        super(Store, self).__init__(Store)
+
+    def __getattr__(self, key):
+        """Override __getattr__ so dot syntax works on keys."""
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __setattr__(self, key, value):
+        """Override __setattr__ so dot syntax works on keys."""
+        self[key] = value
+
+
+store = Store()
+
+
+def timed_memoizer(func):
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        fname = func.__qualname__
+        logger.info("Started: %s" % fname)
+        start_time = datetime.now()
+        if fname in store.keys():
+            ret = store[fname]
+        else:
+            logger.info("Return for {} not cached".format(fname))
+            ret = await func(*args, **kwargs)
+            store[fname] = ret
+        logger.info("Finished: {} in: {} seconds".format(fname, datetime.now() - start_time))
+        return ret
+
+    return wrapper
+
+
+@timed_memoizer
+async def clone_repo_from_branch(repo_url: str, branch: str, clone_root: Path, name: str) -> Path:
+    """Clone a specific branch of a repo into a named subfolder under `clone_root`."""
+    clone_path = clone_root / name
+
+    if clone_path.exists():
+        shutil.rmtree(clone_path)
+
+    subprocess.check_call(
+        ["git", "clone", "-b", branch, "--depth", "1", repo_url, str(clone_path)]
+    )
+    return clone_path
+
+
+# We pull oauth proxy manually from this fork until https://github.com/canonical/oauth2-proxy-k8s-operator/issues/72 is fixed
+@pytest.fixture(scope="module")
+@timed_memoizer
+async def oauth2_proxy_charm(ops_test: OpsTest):
+    repo_url = "https://github.com/IbraAoad/oauth2-proxy-k8s-operator.git"
+    branch = "patch-1"
+    name = "oauth2-proxy-k8s-operator"
+
+    clone_path = await clone_repo_from_branch(repo_url, branch, ops_test.tmp_path, name)
+
+    count = 0
+    while True:
+        try:
+            charm = await ops_test.build_charm(clone_path, verbosity="debug")
+            return charm
+        except RuntimeError:
+            logger.warning("Failed to build oauth2-proxy. Trying again!")
+            count += 1
+
+            if count == 3:
+                raise

--- a/tests/manual/auth/test_setup_auth.py
+++ b/tests/manual/auth/test_setup_auth.py
@@ -1,0 +1,231 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+# Model names
+MODEL_ISTIO = "istio-system"
+MODEL_IAM = "iam"
+MODEL_INGRESS = "ingress"
+
+# Relation endpoints
+INGRESS_CONFIG_RELATION = "istio-ingress-config"
+FORWARD_AUTH_RELATION = "forward-auth"
+CERTIFICATES_RELATION = "certificates"
+OAUTH_RELATION = "oauth"
+DB_RELATION = "pg-database"
+UNAUTH_INGRESS = "ingress-unauthenticated"
+AUTH_INGRESS = "ingress"
+RECEIVE_CA_CERT = "receive-ca-cert"
+SEND_CA_CERT = "send-ca-cert"
+
+oauth2_proxy_resources = {
+    "oauth2-proxy-image": "ghcr.io/canonical/oauth2-proxy:7.8.1",
+}
+
+
+@dataclass
+class CharmDeploymentConfiguration:
+    entity_url: str
+    application_name: str
+    channel: str
+    trust: bool
+    config: Optional[dict] = None
+
+
+# Charm configurations
+ISTIO_K8S = CharmDeploymentConfiguration("istio-k8s", "istio-k8s", "latest/edge", True)
+
+OAUTH2_PROXY = CharmDeploymentConfiguration(
+    "oauth2-proxy-k8s", "oauth2-proxy", "latest/edge", True
+)
+INGRESS_ADMIN = CharmDeploymentConfiguration(
+    "istio-ingress-k8s", "istio-ingress-admin", "latest/edge", True
+)
+INGRESS_PUBLIC = CharmDeploymentConfiguration(
+    "istio-ingress-k8s", "istio-ingress-public", "latest/edge", True
+)
+CERTS = CharmDeploymentConfiguration(
+    "self-signed-certificates",
+    "self-signed-certificates",
+    "latest/stable",
+    False,
+    config={"ca-common-name": "demo.ca.local"},
+)
+CATALOGUE_AUTHED = CharmDeploymentConfiguration(
+    "catalogue-k8s", "catalogue-authed", "latest/edge", True
+)
+CATALOGUE_UNAUTHED = CharmDeploymentConfiguration(
+    "catalogue-k8s", "catalogue-unauthed", "latest/edge", True
+)
+
+HYDRA = CharmDeploymentConfiguration("hydra", "hydra", "latest/edge", True)
+KRATOS = CharmDeploymentConfiguration("kratos", "kratos", "latest/edge", True)
+LOGIN_UI = CharmDeploymentConfiguration(
+    "identity-platform-login-ui-operator",
+    "identity-platform-login-ui-operator",
+    "latest/edge",
+    True,
+)
+POSTGRESQL = CharmDeploymentConfiguration(
+    "postgresql-k8s",
+    "postgresql-k8s",
+    "14/stable",
+    True,
+    config={"plugin_pg_trgm_enable": True, "plugin_btree_gin_enable": True},
+)
+
+
+@pytest.mark.abort_on_fail
+async def test_iam_bundle_split_deploy(ops_test: OpsTest):
+    for model in [MODEL_ISTIO, MODEL_IAM, MODEL_INGRESS]:
+        await ops_test.track_model(alias=model, model_name=model)
+
+    istio_model = ops_test.models[MODEL_ISTIO]
+    iam_model = ops_test.models[MODEL_IAM]
+    ingress_model = ops_test.models[MODEL_INGRESS]
+
+    await istio_model.model.deploy(**asdict(ISTIO_K8S))
+
+    for charm in [HYDRA, KRATOS, LOGIN_UI, POSTGRESQL]:
+        await iam_model.model.deploy(**asdict(charm))
+
+    for charm in [INGRESS_ADMIN, INGRESS_PUBLIC, CERTS, CATALOGUE_AUTHED, CATALOGUE_UNAUTHED]:
+        await ingress_model.model.deploy(**asdict(charm))
+
+    await istio_model.model.wait_for_idle(timeout=1200)
+    await iam_model.model.wait_for_idle(timeout=1200)
+    await ingress_model.model.wait_for_idle(timeout=1200)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_oauth_proxy(ops_test: OpsTest, oauth2_proxy_charm):
+    ingress_model = ops_test.models[MODEL_INGRESS]
+    await ingress_model.model.deploy(
+        oauth2_proxy_charm,
+        resources=oauth2_proxy_resources,
+        application_name="oauth2-proxy",
+        trust=True,
+    )
+    await ingress_model.model.wait_for_idle(["oauth2-proxy"], timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+async def test_relations_setup(ops_test: OpsTest):
+    iam_model = ops_test.models[MODEL_IAM]
+    ingress_model = ops_test.models[MODEL_INGRESS]
+
+    # Create offers
+    offers = [
+        (
+            MODEL_ISTIO,
+            ISTIO_K8S.application_name,
+            INGRESS_CONFIG_RELATION,
+            INGRESS_CONFIG_RELATION,
+        ),
+        (MODEL_IAM, HYDRA.application_name, OAUTH_RELATION, OAUTH_RELATION),
+        (
+            MODEL_INGRESS,
+            INGRESS_PUBLIC.application_name,
+            UNAUTH_INGRESS,
+            "public-ingress-unauthenticated",
+        ),
+        (
+            MODEL_INGRESS,
+            INGRESS_PUBLIC.application_name,
+            AUTH_INGRESS,
+            "public-ingress-authenticated",
+        ),
+        (MODEL_INGRESS, INGRESS_ADMIN.application_name, AUTH_INGRESS, "admin-ingress"),
+    ]
+    for model, app, endpoint, offer_name in offers:
+        full = f"{model}.{app}:{endpoint}"
+        await ops_test.juju("offer", full, offer_name)
+
+    # Consume offers
+    consumes = [
+        (MODEL_INGRESS, f"admin/{MODEL_ISTIO}.{INGRESS_CONFIG_RELATION}"),
+        (MODEL_INGRESS, f"admin/{MODEL_IAM}.{OAUTH_RELATION}"),
+        (MODEL_IAM, f"admin/{MODEL_INGRESS}.public-ingress-unauthenticated"),
+        (MODEL_IAM, f"admin/{MODEL_INGRESS}.public-ingress-authenticated"),
+        (MODEL_IAM, f"admin/{MODEL_INGRESS}.admin-ingress"),
+    ]
+    for model, offer in consumes:
+        await ops_test.juju("consume", offer, "--model", model)
+
+    # IAM model relations
+    iam_relations = [
+        (f"{HYDRA.application_name}:{DB_RELATION}", f"{POSTGRESQL.application_name}:database"),
+        (f"{KRATOS.application_name}:{DB_RELATION}", f"{POSTGRESQL.application_name}:database"),
+        (
+            f"{KRATOS.application_name}:hydra-endpoint-info",
+            f"{HYDRA.application_name}:hydra-endpoint-info",
+        ),
+        (
+            f"{LOGIN_UI.application_name}:hydra-endpoint-info",
+            f"{HYDRA.application_name}:hydra-endpoint-info",
+        ),
+        (
+            f"{LOGIN_UI.application_name}:ui-endpoint-info",
+            f"{HYDRA.application_name}:ui-endpoint-info",
+        ),
+        (
+            f"{LOGIN_UI.application_name}:ui-endpoint-info",
+            f"{KRATOS.application_name}:ui-endpoint-info",
+        ),
+        (f"{LOGIN_UI.application_name}:kratos-info", f"{KRATOS.application_name}:kratos-info"),
+        (f"{HYDRA.application_name}:admin-ingress", "admin-ingress"),
+        (f"{KRATOS.application_name}:admin-ingress", "admin-ingress"),
+        (f"{KRATOS.application_name}:public-ingress", "public-ingress-unauthenticated"),
+        (f"{HYDRA.application_name}:public-ingress", "public-ingress-unauthenticated"),
+        (f"{LOGIN_UI.application_name}:ingress", "public-ingress-unauthenticated"),
+    ]
+    for a, b in iam_relations:
+        await iam_model.model.add_relation(a, b)
+
+    # Ingress model relations
+    ingress_relations = [
+        (
+            f"{OAUTH2_PROXY.application_name}:ingress",
+            f"{INGRESS_PUBLIC.application_name}:{UNAUTH_INGRESS}",
+        ),
+        (
+            f"{CATALOGUE_UNAUTHED.application_name}:ingress",
+            f"{INGRESS_PUBLIC.application_name}:{UNAUTH_INGRESS}",
+        ),
+        (
+            f"{CATALOGUE_AUTHED.application_name}:ingress",
+            f"{INGRESS_PUBLIC.application_name}:{AUTH_INGRESS}",
+        ),
+        (
+            f"{INGRESS_ADMIN.application_name}:{CERTIFICATES_RELATION}",
+            f"{CERTS.application_name}:{CERTIFICATES_RELATION}",
+        ),
+        (
+            f"{INGRESS_PUBLIC.application_name}:{CERTIFICATES_RELATION}",
+            f"{CERTS.application_name}:{CERTIFICATES_RELATION}",
+        ),
+        (
+            f"{OAUTH2_PROXY.application_name}:{RECEIVE_CA_CERT}",
+            f"{CERTS.application_name}:{SEND_CA_CERT}",
+        ),
+        (f"{OAUTH2_PROXY.application_name}:{OAUTH_RELATION}", OAUTH_RELATION),
+        (f"{INGRESS_PUBLIC.application_name}:{INGRESS_CONFIG_RELATION}", INGRESS_CONFIG_RELATION),
+        (
+            f"{OAUTH2_PROXY.application_name}:{FORWARD_AUTH_RELATION}",
+            f"{INGRESS_PUBLIC.application_name}:{FORWARD_AUTH_RELATION}",
+        ),
+    ]
+    for a, b in ingress_relations:
+        await ingress_model.model.add_relation(a, b)
+
+    # Final wait for all models to be active/idle
+    for model in ops_test.models.values():
+        await model.model.wait_for_idle(status="active", timeout=1000, wait_for_active=True)

--- a/tox.ini
+++ b/tox.ini
@@ -102,3 +102,19 @@ commands =
            --log-cli-level=INFO \
            {posargs} \
            {[vars]tests_path}/integration
+
+[testenv:auth-setup]
+description = Run manual auth setup test
+deps =
+    pytest
+    pytest-asyncio
+    pytest-operator
+    juju
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           {[vars]tests_path}/manual/auth


### PR DESCRIPTION
This PR introduces a manual integration test to validate OAuth2 authentication flow with Istio ingress.

Key additions include:
- A new `auth-setup` test that spins up all components in a multi-juju-model fashion :
  - Istio-k8s in a dedicated `istio-system` model
  - IAM components (Kratos, Hydra, Login UI, PostgreSQL) in the `iam` model
  - Ingress-related components (ingress charms, oauth2-proxy, certs, 2 catalogue instaces) in the `ingress` model
  - The `catalogue` charms are not essential to the authentication flow itself; they serve as simple placeholders to manually validate ingress behavior with the auth flow and can be replaced with any charm that integrates with the `istio-ingress` charm via the `ingress` relation.



**Note:**
the `oauth2-proxy` charm is being pulled from this fork https://github.com/IbraAoad/oauth2-proxy-k8s-operator until https://github.com/canonical/oauth2-proxy-k8s-operator/issues/72 is fixed