### PR TITLE
fix: point integration tests at the current development branch for istio charms

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,5 +1,6 @@
 import logging
 import ssl
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, cast
 from urllib.parse import urlparse
 
@@ -317,3 +318,17 @@ class DNSResolverHTTPSAdapter(HTTPAdapter):
                 connection_pool_kwargs.pop("assert_hostname", None)
 
         return super().send(request, stream, timeout, verify, cert, proxies)
+
+
+@dataclass
+class CharmDeploymentConfiguration:
+    entity_url: str  # aka charm name or local path to charm
+    application_name: str
+    channel: str
+    trust: bool
+    config: Optional[dict] = None
+
+
+istio_k8s = CharmDeploymentConfiguration(
+    entity_url="istio-k8s", application_name="istio-k8s", channel="2/edge", trust=True
+)

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
@@ -19,6 +19,7 @@ from helpers import (
     get_listener_condition,
     get_listener_spec,
     get_route_condition,
+    istio_k8s,
     send_http_request,
     send_http_request_with_custom_ca,
 )
@@ -36,20 +37,6 @@ resources = {
 }
 
 
-@dataclass
-class CharmDeploymentConfiguration:
-    entity_url: str  # aka charm name or local path to charm
-    application_name: str
-    channel: str
-    trust: bool
-    config: Optional[dict] = None
-
-
-ISTIO_K8S = CharmDeploymentConfiguration(
-    entity_url="istio-k8s", application_name="istio-k8s", channel="latest/edge", trust=True
-)
-
-
 @pytest.mark.abort_on_fail
 async def test_deploy_dependencies(ops_test: OpsTest, ipa_tester_charm):
     """Deploys dependencies across two models: one for Istio and one for ipa-tester.
@@ -64,10 +51,10 @@ async def test_deploy_dependencies(ops_test: OpsTest, ipa_tester_charm):
     istio_core = ops_test.models.get("istio-core")
 
     # Deploy Istio-k8s
-    await istio_core.model.deploy(**asdict(ISTIO_K8S))
+    await istio_core.model.deploy(**asdict(istio_k8s))
     await istio_core.model.wait_for_idle(
         [
-            ISTIO_K8S.application_name,
+            istio_k8s.application_name,
         ],
         status="active",
         timeout=1000,

--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -3,13 +3,12 @@
 
 import asyncio
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
-from typing import Optional
 
 import pytest
 import yaml
-from helpers import get_hpa
+from helpers import get_hpa, istio_k8s
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -21,28 +20,14 @@ resources = {
 }
 
 
-@dataclass
-class CharmDeploymentConfiguration:
-    entity_url: str  # aka charm name or local path to charm
-    application_name: str
-    channel: str
-    trust: bool
-    config: Optional[dict] = None
-
-
-ISTIO_K8S = CharmDeploymentConfiguration(
-    entity_url="istio-k8s", application_name="istio-k8s", channel="latest/edge", trust=True
-)
-
-
 @pytest.mark.abort_on_fail
 async def test_deploy_dependencies(ops_test: OpsTest):
     """Deploy istio as a dependency."""
     # Deploy Istio-k8s
-    await ops_test.model.deploy(**asdict(ISTIO_K8S))
+    await ops_test.model.deploy(**asdict(istio_k8s))
     await ops_test.model.wait_for_idle(
         [
-            ISTIO_K8S.application_name,
+            istio_k8s.application_name,
         ],
         status="active",
         timeout=1000,


### PR DESCRIPTION
## Issue
Previously, integration tests deployed istio-k8s from channel `latest/edge` because that was the leading edge development branch.  Now that we've cut a `1` track for the prior release and a `2` track for current development, we need to point at `2/edge`.  We cannot simply point at `edge`, because `1` is the default track


## Solution
Point the test at `2/edge`

## Context


## Testing Instructions


## Upgrade Notes
