### PR TITLE
feat: forward auth headers from forward_auth to istio_ingress_config

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -64,7 +64,8 @@ def test_ext_authz_setup(
     state = scenario.State(relations=relations, leader=True)
     out = istio_ingress_context.run(istio_ingress_context.on.config_changed(), state)
 
-    mock_publish.assert_called_once_with(expected_decision)
+    # forward_auth_headers will be None because the test fixture has empty headers
+    mock_publish.assert_called_once_with(expected_decision, None)
     mock_sync.assert_called_once_with(expected_decision, [])
     assert isinstance(out.unit_status, ActiveStatus)
     assert out.unit_status.message.startswith("Serving at")


### PR DESCRIPTION
## Issue
fixes #121 


## Context and Solution
for external authorization, istio lets various headers to be defined. currently, these headers in the `istio-k8s` charm are hardcoded to be the oauth2_proxy standards. but the OAuth provider can be varying and the header values depends on the provider. The forward_auth library allows the OAuth provider to specify the headers to be passed to the upstream service on successful authentication. This `istio-k8s` [PR](https://github.com/canonical/istio-k8s-operator/pull/100) extends the istio_ingress_config to pass these headers to the istio-k8s charm. 

This PR updates the `istio-ingress-k8s` charm to pass the headers from the `forward-auth` relation to the `istio-k8s` charm via the `istio-ingress-config` relation.


## Testing Instructions
The manual testing instructions [here](https://github.com/canonical/istio-ingress-k8s-operator/tree/main/tests/manual/auth) can be used to test the auth and verify the working. (But the hydra based oauth provider uses oauth2 proxy, so we will still see the default headers)
