### PR TITLE
feat: adds support to upstream ingress

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -123,6 +123,14 @@ requires:
   forward-auth:
     interface: forward_auth
     limit: 1
+  upstream-ingress:
+    interface: ingress
+    limit: 1
+    description: |
+      Configure to use an ingress upstream of this gateway. Useful when you want an internal
+      gateway that is then exposed by an additional external ingress.
+      When upstream ingress is configured, the URLs published to downstream consumers will use
+      the upstream ingress's address rather than this gateway's load balancer address.
 
 resources:
   metrics-proxy-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ import ipaddress
 import logging
 import re
 import time
-from typing import Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 from urllib.parse import urlparse
 
 from charmed_service_mesh_helpers import (
@@ -39,6 +39,7 @@ from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
 from charms.traefik_k8s.v2.ingress import IngressPerAppProvider as IPAv2
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.generic_resource import create_namespaced_resource
@@ -140,6 +141,7 @@ GRPC_DESTINATION_RULE_SCOPE = "grpc-destination-rule"
 
 INGRESS_CONFIG_RELATION = "istio-ingress-config"
 FORWARD_AUTH_RELATION = "forward-auth"
+UPSTREAM_INGRESS_RELATION = "upstream-ingress"
 PEERS_RELATION = "peers"
 
 
@@ -193,6 +195,19 @@ class IstioIngressCharm(CharmBase):
             ),
         }
         self.telemetry_labels = generate_telemetry_labels(self.app.name, self.model.name)
+
+        # Setup 'upstream-ingress' relation to allow this istio-ingress to be ingressed
+        # through another ingress provider (e.g., to layer multiple ingresses).
+        # Accurate data (scheme, port based on TLS) is sent on every reconciliation via
+        # provide_ingress_requirements() in _sync_all_resources.
+        self.upstream_ingress = IngressPerAppRequirer(
+            charm=self,
+            relation_name=UPSTREAM_INGRESS_RELATION,
+            strip_prefix=True,
+            host=self._local_gateway_address,
+            port=80,
+        )
+
         # Configure Observability
         self._scraping = MetricsEndpointProvider(
             self,
@@ -244,10 +259,17 @@ class IstioIngressCharm(CharmBase):
         self.framework.observe(
             self.on["gateway-metadata"].relation_changed, self._on_gateway_metadata_relation_changed
         )
+        self.framework.observe(
+            self.upstream_ingress.on.ready, self._handle_upstream_ingress_changed
+        )
+        self.framework.observe(
+            self.upstream_ingress.on.revoked, self._handle_upstream_ingress_changed
+        )
 
         # During the initialisation of the charm, we do not have a LoadBalancer and thus a LoadBalancer external IP.
         # If we need that IP to request the certs, disable cert handling until we have it.
-        if (external_hostname := self._ingress_url) is None:
+        # Always use the local gateway address for certs (not cascaded upstream address).
+        if (external_hostname := self._local_gateway_address) is None:
             logger.debug(
                 "External hostname is not set and no load balancer ip available.  TLS certificate generation disabled"
             )
@@ -555,7 +577,9 @@ class IstioIngressCharm(CharmBase):
             Gateway lightkube resource
         """
         allowed_routes = AllowedRoutes(namespaces={"from": "All"})
-        hostname = self._ingress_url if self._is_valid_hostname(self._ingress_url) else None
+        # Use local gateway address for the K8s Gateway resource hostname,
+        # not the cascaded upstream address
+        hostname = self._local_gateway_address if self._is_valid_hostname(self._local_gateway_address) else None
 
         listeners = []
         for norm_listener in normalized_listeners:
@@ -807,6 +831,13 @@ class IstioIngressCharm(CharmBase):
                 "Invalid hostname provided, Please ensure this adheres to RFC 1123."
             )
             return
+
+        # Update upstream ingress relation with current host, port, and scheme.
+        # This ensures the upstream always has fresh data about how to reach this gateway.
+        # No-op if no upstream ingress is related.
+        self.upstream_ingress.provide_ingress_requirements(
+            **self._generate_upstream_ingress_route_configuration()
+        )
 
         # Synchronize ingress resources
         try:
@@ -1320,8 +1351,7 @@ class IstioIngressCharm(CharmBase):
 
         This may return None if no ingress load balancer exists.
         """
-        scheme = "https" if self._construct_gateway_tls_secret() is not None else "http"
-        return f"{scheme}://{self._ingress_url}"
+        return f"{self._ingressed_scheme}://{self._ingress_url}"
 
     @property
     def _ingress_url(self) -> Optional[str]:
@@ -1329,9 +1359,10 @@ class IstioIngressCharm(CharmBase):
 
         This will return one of (in order of preference):
         1. the value cached from a previous call to _ingress_url, even if this value has since changed
-        2. the `external-hostname` config if that is set
-        3. the load balancer address for the ingress gateway, if it exists and has an IP
-        4. None
+        2. the upstream ingress URL if an upstream ingress is configured and ready
+        3. the `external-hostname` config if that is set
+        4. the load balancer address for the ingress gateway, if it exists and has an IP
+        5. None
 
         Preference is given to the previously cached value because this charm may make several calls to this method in
         a single charm execution and the value of the load balancer address may change during that time.  Without this
@@ -1342,16 +1373,17 @@ class IstioIngressCharm(CharmBase):
         if self._ingress_url_ is not None:
             return self._ingress_url_
 
-        if external_hostname := self.model.config.get("external_hostname"):
-            hostname = cast(str, external_hostname)
-            if self._is_valid_hostname(hostname):
-                self._ingress_url_ = hostname
-                return self._ingress_url_
-            logger.error("Invalid hostname provided, Please ensure this adheres to RFC 1123")
-            return None
+        # Cascade: use upstream ingress URL if available
+        if self.upstream_ingress.is_ready():
+            url = cast(str, self.upstream_ingress.url)
+            parsed = urlparse(url)
+            address = url.replace(f"{parsed.scheme}://", "", 1).rstrip("/")
+            self._ingress_url_ = address
+            return self._ingress_url_
 
-        if lb_external_address := self._get_lb_external_address:
-            self._ingress_url_ = lb_external_address
+        # Fallback to local gateway address
+        if local_address := self._local_gateway_address:
+            self._ingress_url_ = local_address
             return self._ingress_url_
 
         logger.debug(
@@ -1360,6 +1392,50 @@ class IstioIngressCharm(CharmBase):
         )
 
         return None
+
+    @property
+    def _local_gateway_address(self) -> Optional[str]:
+        """Return the LOCAL address of this gateway (external_hostname or LB address).
+
+        Unlike _ingress_url (which cascades through upstream ingress), this always
+        returns the direct address of this gateway. Used to tell the upstream ingress
+        where to route traffic to reach this gateway, and for CertHandler SANs.
+        """
+        if external_hostname := self.model.config.get("external_hostname"):
+            hostname = cast(str, external_hostname)
+            if self._is_valid_hostname(hostname):
+                return hostname
+            return None
+        return self._get_lb_external_address
+
+    @property
+    def _ingressed_scheme(self) -> str:
+        """Return the scheme for the ingressed address.
+
+        If upstream ingress is configured and ready, returns the upstream's scheme.
+        Otherwise, returns scheme based on local TLS configuration.
+        """
+        if self.upstream_ingress.is_ready():
+            return str(urlparse(self.upstream_ingress.url).scheme)
+        return "https" if self._construct_gateway_tls_secret() is not None else "http"
+
+    def _generate_upstream_ingress_route_configuration(self) -> Dict[str, Any]:
+        """Return the scheme, host, port, and ip needed for the upstream ingress relation.
+
+        This tells the upstream ingress provider what address, port, and scheme to use
+        to route traffic to this istio-ingress gateway.
+        """
+        is_tls = self._construct_gateway_tls_secret() is not None
+        return {
+            "scheme": "https" if is_tls else "http",
+            "host": self._local_gateway_address,
+            "port": 443 if is_tls else 80,
+            "ip": self._get_lb_external_address,
+        }
+
+    def _handle_upstream_ingress_changed(self, _):
+        """Handle change in the upstream ingress relation."""
+        self._sync_all_resources()
 
     @staticmethod
     def _generate_default_path(app_name: str, model: str) -> str:

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,13 +5,18 @@ output "app_name" {
 output "endpoints" {
   value = {
     # Requires
-    certificates  = "certificates"
-    charm-tracing = "charm-tracing"
-    forward-auth  = "forward-auth"
+    certificates     = "certificates"
+    charm-tracing    = "charm-tracing"
+    forward-auth     = "forward-auth"
+    upstream-ingress = "upstream-ingress"
 
     # Provides
-    ingress                 = "ingress"
-    ingress-unauthenticated = "ingress-unauthenticated"
-    metrics-endpoint        = "metrics-endpoint"
+    ingress                             = "ingress"
+    ingress-unauthenticated             = "ingress-unauthenticated"
+    metrics-endpoint                    = "metrics-endpoint"
+    istio-ingress-config                = "istio-ingress-config"
+    istio-ingress-route                 = "istio-ingress-route"
+    istio-ingress-route-unauthenticated = "istio-ingress-route-unauthenticated"
+    gateway-metadata                    = "gateway-metadata"
   }
 }

--- a/tests/integration/test_upstream_ingress.py
+++ b/tests/integration/test_upstream_ingress.py
@@ -15,7 +15,7 @@ from helpers import (
     send_http_request,
     send_http_request_with_custom_ca,
 )
-from jubilant import Juju, all_active
+from jubilant import Juju, all_active, all_agents_idle
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +90,14 @@ def test_add_tls(juju: Juju):
     )
     juju.integrate(f"{SELF_SIGNED_CERTS}:certificates", f"{APP_NAME}:certificates")
     juju.integrate(f"{SELF_SIGNED_CERTS}:certificates", f"{TRAEFIK_APP}:certificates")
+    # Wait for all apps active AND all unit agents idle. After TLS integration there's
+    # a cascade: certs issued → traefik updates URL to https → istio-ingress picks up
+    # new URL → republishes to downstream apps.  all_active alone only checks workload
+    # status (stays "active" throughout), so we also need all_agents_idle to ensure
+    # no hooks are still executing.
     juju.wait(
-        lambda s: all_active(s, APP_NAME, TRAEFIK_APP, SELF_SIGNED_CERTS, IPA_TESTER),
+        lambda s: all_active(s, APP_NAME, TRAEFIK_APP, SELF_SIGNED_CERTS, IPA_TESTER)
+        and all_agents_idle(s, APP_NAME, TRAEFIK_APP, SELF_SIGNED_CERTS, IPA_TESTER),
         timeout=1000,
         delay=5,
         successes=3,

--- a/tests/integration/test_upstream_ingress.py
+++ b/tests/integration/test_upstream_ingress.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for upstream ingress chaining with traefik-k8s."""
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from conftest import get_relation_data
+from helpers import (
+    get_ca_certificate,
+    get_k8s_service_address,
+    send_http_request,
+    send_http_request_with_custom_ca,
+)
+from jubilant import Juju, all_active
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+TRAEFIK_APP = "traefik-k8s"
+IPA_TESTER = "ipa-tester"
+SELF_SIGNED_CERTS = "self-signed-certificates"
+
+
+@pytest.mark.setup
+@pytest.mark.dependency(name="test_deploy")
+def test_deploy(juju: Juju, istio_core_juju: Juju, istio_ingress_charm, resources, tester_http_charm):
+    """Deploy istio-ingress, traefik (upstream), and tester charms."""
+    juju.deploy(istio_ingress_charm, resources=resources, app=APP_NAME, trust=True)
+    juju.deploy(TRAEFIK_APP, channel="latest/edge", trust=True)
+    juju.deploy(
+        tester_http_charm,
+        app=IPA_TESTER,
+        resources={"echo-server-image": "jmalloc/echo-server:v0.3.7"},
+    )
+    juju.wait(
+        lambda s: all_active(s, APP_NAME, TRAEFIK_APP, IPA_TESTER),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
+
+
+@pytest.mark.dependency(name="test_relate", depends=["test_deploy"])
+def test_relate(juju: Juju):
+    """Relate tester to istio-ingress and istio-ingress to traefik upstream."""
+    juju.integrate(f"{IPA_TESTER}:ingress", f"{APP_NAME}:ingress")
+    juju.integrate(f"{APP_NAME}:upstream-ingress", f"{TRAEFIK_APP}:ingress")
+    juju.wait(
+        lambda s: all_active(s, APP_NAME, TRAEFIK_APP, IPA_TESTER),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
+
+
+@pytest.mark.dependency(name="test_http_through_upstream", depends=["test_relate"])
+def test_http_through_upstream(juju: Juju):
+    """Test HTTP connectivity through the traefik -> istio chain."""
+    data = get_relation_data(
+        requirer_endpoint=f"{IPA_TESTER}/0:ingress",
+        provider_endpoint=f"{APP_NAME}/0:ingress",
+        model=juju.model,
+    )
+    provider_app_data = yaml.safe_load(data.provider.application_data["ingress"])
+    url = provider_app_data["url"]
+
+    # Verify URL is cascaded through upstream (not pointing at istio's local LB)
+    istio_address = get_k8s_service_address(juju.model, f"{APP_NAME}-istio")
+    assert istio_address not in url, (
+        f"Expected cascaded URL through upstream, not direct istio address: {url}"
+    )
+
+    assert send_http_request(url), f"Failed to reach tester through upstream chain: {url}"
+
+
+@pytest.mark.dependency(name="test_add_tls", depends=["test_http_through_upstream"])
+def test_add_tls(juju: Juju):
+    """Add TLS to both istio-ingress and traefik via self-signed-certificates."""
+    juju.deploy(SELF_SIGNED_CERTS)
+    juju.wait(
+        lambda s: all_active(s, SELF_SIGNED_CERTS),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
+    juju.integrate(f"{SELF_SIGNED_CERTS}:certificates", f"{APP_NAME}:certificates")
+    juju.integrate(f"{SELF_SIGNED_CERTS}:certificates", f"{TRAEFIK_APP}:certificates")
+    juju.wait(
+        lambda s: all_active(s, APP_NAME, TRAEFIK_APP, SELF_SIGNED_CERTS, IPA_TESTER),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
+
+
+@pytest.mark.dependency(name="test_https_through_upstream", depends=["test_add_tls"])
+def test_https_through_upstream(juju: Juju):
+    """Test HTTPS connectivity through the traefik -> istio chain with TLS on both."""
+    data = get_relation_data(
+        requirer_endpoint=f"{IPA_TESTER}/0:ingress",
+        provider_endpoint=f"{APP_NAME}/0:ingress",
+        model=juju.model,
+    )
+    provider_app_data = yaml.safe_load(data.provider.application_data["ingress"])
+    url = provider_app_data["url"]
+
+    assert url.startswith("https://"), f"Expected HTTPS URL after TLS setup, got: {url}"
+
+    ca_cert = get_ca_certificate(juju, f"{SELF_SIGNED_CERTS}/0")
+    traefik_address = get_k8s_service_address(juju.model, TRAEFIK_APP)
+
+    assert (
+        send_http_request_with_custom_ca(url, ca_cert, resolve_netloc_to_ip=traefik_address) == 200
+    ), f"Failed to reach tester through upstream chain with TLS: {url}"

--- a/tests/unit/test_upstream_ingress.py
+++ b/tests/unit/test_upstream_ingress.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the upstream-ingress chaining feature."""
+
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from ops.testing import Harness
+
+from charm import IstioIngressCharm
+
+
+@pytest.fixture()
+def harness():
+    harness = Harness(IstioIngressCharm)
+    harness.set_model_name("istio-system")
+    yield harness
+    harness.cleanup()
+
+
+def test_ingress_url_cascades_through_upstream(harness):
+    """When upstream ingress is ready, _ingress_url returns the upstream URL with scheme stripped."""
+    harness.begin()
+    charm = harness.charm
+    charm._ingress_url_ = None
+
+    with patch.object(
+        charm.upstream_ingress, "is_ready", return_value=True
+    ), patch.object(
+        IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
+    ):
+        assert charm._ingress_url == "upstream.example.com/model-app"
+
+
+def test_ingress_url_falls_back_without_upstream(harness):
+    """Without upstream, _ingress_url returns external_hostname or LB address."""
+    harness.begin()
+    charm = harness.charm
+    charm._ingress_url_ = None
+
+    with patch.object(
+        charm.upstream_ingress, "is_ready", return_value=False
+    ), patch(
+        "charm.IstioIngressCharm._get_lb_external_address",
+        new_callable=PropertyMock,
+        return_value="10.1.1.1",
+    ):
+        assert charm._ingress_url == "10.1.1.1"
+
+
+def test_ingress_url_with_scheme_uses_upstream(harness):
+    """_ingress_url_with_scheme returns the full cascaded URL including the upstream's scheme."""
+    harness.begin()
+    charm = harness.charm
+    charm._ingress_url_ = None
+
+    with patch.object(
+        charm.upstream_ingress, "is_ready", return_value=True
+    ), patch.object(
+        IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
+    ):
+        assert charm._ingress_url_with_scheme() == "https://upstream.example.com/model-app"
+
+
+def test_construct_gateway_uses_local_address_not_upstream(harness):
+    """The Gateway K8s resource hostname should use the local address, not the cascaded upstream."""
+    harness.update_config({"external_hostname": "local.example.com"})
+    harness.begin()
+    charm = harness.charm
+
+    with patch.object(
+        charm.upstream_ingress, "is_ready", return_value=True
+    ), patch.object(
+        IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
+    ):
+        listeners = [{"port": 80, "gateway_protocol": "HTTP", "tls_secret_name": None, "source_app": "test"}]
+        gateway = charm._construct_gateway(listeners)
+        assert gateway.spec["listeners"][0]["hostname"] == "local.example.com"


### PR DESCRIPTION
## Issue
Fixes #142 

## Solution
Adds an `upstream-ingress` relation over the `ingress` interface. to access apps in a chained ingress setup

## Testing Instructions
Can be tested by deploying a `traefik-k8s` charm infront of the istio-ingress-k8s charm and trying to reach the workloads via the outermost ingress
