### PR TITLE
fix: enter blocked status when the same ingress path is requested by multiple apps

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -727,6 +727,7 @@ class IstioIngressCharm(CharmBase):
         """Synchronize all resources including authentication, gateway, ingress, and certificates.
 
         Flow:
+        * Create a list of events (soft blockers) that do not break the flow but set a blocked state at the end.
         * Check authentication configuration.
         * Publish or clear the auth_decisions_address in ingress-config, if related.
         * If auth relation exists but no decisions address, set to blocked and remove gateway.
@@ -742,10 +743,14 @@ class IstioIngressCharm(CharmBase):
         * Set up the proxy service.
         * Update forward auth relation data with ingressed apps.
         * Request certificate inspection.
+        * Set the final status based on soft blockers.
         """
         if not self.unit.is_leader():
             self.unit.status = ActiveStatus("Backup unit; standing by for leader takeover")
             return
+
+        # Create a list of events (soft blockers) that do not break the flow but set a blocked state at the end.
+        soft_blockers = []
 
         # Check authentication configuration.
         auth_decisions_address = self._get_oauth_decisions_address()
@@ -793,9 +798,10 @@ class IstioIngressCharm(CharmBase):
         valid_grpc_routes, grpc_apps_to_clear = deduplicate_grpc_routes(istio_grpc_routes)  # ipa relation doesnt support grpc routes.
 
         # Clear conflicts from original structures (needed for publishing back to apps)
-        # TODO: Capture a BlockedStatus here if there's duplicates
-        #  (https://github.com/canonical/istio-ingress-k8s-operator/issues/57)
         all_apps_to_clear = http_apps_to_clear | grpc_apps_to_clear
+        logger.error(str(all_apps_to_clear))
+        if len(all_apps_to_clear) > 0:
+            soft_blockers.append("Route conflict detected. Check the logs for more information.")
         clear_conflicting_routes(
             application_route_data, istio_ingress_route_configs, all_apps_to_clear
         )
@@ -877,6 +883,13 @@ class IstioIngressCharm(CharmBase):
             "Requesting CertHandler inspect certs to decide if our CSR has changed and we should re-request"
         )
         self.on.refresh_certs.emit()
+
+        # Set the final status based on soft blockers
+        self._set_final_status(soft_blockers)
+
+    def _set_final_status(self,soft_blockers):
+        if len(soft_blockers) > 0:
+            self.unit.status = BlockedStatus(str(soft_blockers[0]))
 
     def _get_oauth_decisions_address(self) -> Optional[str]:
         """Retrieve the auth configuration decisions_address if it exists.

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ import ipaddress
 import logging
 import re
 import time
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
 from charmed_service_mesh_helpers import (
@@ -54,9 +54,9 @@ from lightkube.resources.core_v1 import Secret, Service
 from lightkube.types import PatchType
 from lightkube_extensions.batch import KubernetesResourceManager, create_charm_default_labels
 from lightkube_extensions.types import AuthorizationPolicy
-from ops import BlockedStatus, CollectStatusEvent, StoredState, main
+from ops import BlockedStatus, CollectStatusEvent, main
 from ops.charm import CharmBase
-from ops.model import ActiveStatus, MaintenanceStatus, StatusBase
+from ops.model import ActiveStatus, MaintenanceStatus
 from ops.pebble import ChangeError, Layer
 
 from models import (
@@ -156,17 +156,10 @@ PEERS_RELATION = "peers"
 class IstioIngressCharm(CharmBase):
     """Charm the service."""
 
-    _stored = StoredState()
-
     def __init__(self, *args):
         super().__init__(*args)
 
         # display a status based on the current state
-        self._stored.set_default(
-            sync_status_name="active",
-            sync_status_message="",
-            are_routes_removed=False,
-        )
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
 
         # Add a custom event that we can emit to request a cert refresh
@@ -545,20 +538,7 @@ class IstioIngressCharm(CharmBase):
         return ingress_address.hostname or ingress_address.ip
 
     def _is_ready(self) -> bool:
-        if not self._is_deployment_ready():
-            self._set_sync_status(
-                BlockedStatus("Gateway k8s deployment not ready, is istio properly installed?")
-            )
-            return False
-        if not self._is_load_balancer_ready():
-            self._set_sync_status(
-                BlockedStatus(
-                    "Gateway load balancer is unable to obtain an IP or hostname from the cluster."
-                )
-            )
-            return False
-
-        return True
+        return self._is_deployment_ready() and self._is_load_balancer_ready()
 
     def _construct_gateway_tls_secret(self):
         """Return the TLS secret resource for the gateway if TLS is configured, otherwise None."""
@@ -736,16 +716,26 @@ class IstioIngressCharm(CharmBase):
             ),
         )
 
-    def _set_sync_status(self, status: StatusBase):
-        self._stored.sync_status_name = status.name
-        self._stored.sync_status_message = status.message
+    def _is_tls_enabled(self) -> bool:
+        return self._construct_gateway_tls_secret() is not None
 
-    def _get_sync_status(self) -> StatusBase:
-        name = self._stored.sync_status_name
-        message = self._stored.sync_status_message
-        return StatusBase.from_name(name, message)
+    def _get_normalized_istio_routes(self) -> Tuple[List[HTTPRoute],List[GRPCRoute]]:
+        """Return the normalized Istio routes."""
+        is_tls_enabled = self._is_tls_enabled()
+        istio_ingress_route_configs = self._get_istio_ingress_route_configs()
+        istio_http_routes = normalize_istio_ingress_route_http_routes(
+            istio_ingress_route_configs, is_tls_enabled, self.app.name
+        )
+        istio_grpc_routes = normalize_istio_ingress_route_grpc_routes(
+            istio_ingress_route_configs, is_tls_enabled, self.app.name
+        )
+        return istio_http_routes, istio_grpc_routes
 
-    def _sync_all_resources(self):
+    def _get_normalized_ipa_routes(self) -> List[HTTPRoute]:
+        """Return the normalized IPA routes from both sources."""
+        return normalize_ipa_routes(self._get_routes(), self._is_tls_enabled(), self.app.name)
+
+    def _sync_all_resources(self) -> None:
         """Synchronize all resources including authentication, gateway, ingress, and certificates.
 
         Flow:
@@ -756,7 +746,7 @@ class IstioIngressCharm(CharmBase):
         * Fetch route and listeners information from the istio-ingress-route relation.
         * Aggregate and deduplicate the routes and listeners from all supported ingress relations.
         * Synchronize external authorization configuration.
-            - If missing valid ingress-config relation when auth is provided, set to blocked and remove gateway.
+            - If missing valid ingress-config relation when auth is provided, remove gateway.
         * Reconcile HPA and gateway resources to align replicas with unit count and ensure gateway readiness.
         * Validate the external hostname.
         * Synchronize ingress resources.
@@ -766,11 +756,7 @@ class IstioIngressCharm(CharmBase):
         * Request certificate inspection.
         """
         if not self.unit.is_leader():
-            self._set_sync_status(ActiveStatus("Backup unit; standing by for leader takeover"))
             return
-
-        # reset state variable(s) related to the sync process
-        self._stored.are_routes_removed = False
 
         # Check authentication configuration.
         auth_decisions_address = self._get_oauth_decisions_address()
@@ -780,11 +766,8 @@ class IstioIngressCharm(CharmBase):
         if self.model.get_relation(INGRESS_CONFIG_RELATION):
             self._publish_to_istio_ingress_config_relation(auth_decisions_address, forward_auth_headers)
 
-        # If auth relation exists but no decisions address, set to blocked and remove gateway.
+        # If auth relation exists but no decisions address, remove gateway.
         if self.model.get_relation(FORWARD_AUTH_RELATION) and not auth_decisions_address:
-            self._set_sync_status(
-                BlockedStatus("Authentication configuration incomplete; ingress is disabled.")
-            )
             self._remove_gateway_resources()
             return
 
@@ -793,9 +776,7 @@ class IstioIngressCharm(CharmBase):
         istio_ingress_route_configs = self._get_istio_ingress_route_configs()
 
         # Normalize data to common intermediate formats
-        tls_secret = self._construct_gateway_tls_secret()
-        is_tls_enabled = tls_secret is not None
-        tls_secret_name = self._certificate_secret_name if is_tls_enabled else None
+        tls_secret_name = self._certificate_secret_name if self._is_tls_enabled() else None
 
         # Normalize listeners from both sources
         ipa_listeners = normalize_ipa_listeners(tls_secret_name)
@@ -804,13 +785,8 @@ class IstioIngressCharm(CharmBase):
         )
 
         # Normalize routes from both sources
-        ipa_http_routes = normalize_ipa_routes(application_route_data, is_tls_enabled, self.app.name)
-        istio_http_routes = normalize_istio_ingress_route_http_routes(
-            istio_ingress_route_configs, is_tls_enabled, self.app.name
-        )
-        istio_grpc_routes = normalize_istio_ingress_route_grpc_routes(
-            istio_ingress_route_configs, is_tls_enabled, self.app.name
-        )
+        ipa_http_routes = self._get_normalized_ipa_routes()
+        istio_http_routes, istio_grpc_routes = self._get_normalized_istio_routes()
 
         # Merge and deduplicate using source-agnostic functions
         unique_listeners = deduplicate_listeners(ipa_listeners + istio_listeners)
@@ -819,7 +795,6 @@ class IstioIngressCharm(CharmBase):
 
         # Clear conflicts from original structures (needed for publishing back to apps)
         all_apps_to_clear = http_apps_to_clear | grpc_apps_to_clear
-        self._stored.are_routes_removed = len(all_apps_to_clear) > 0
         clear_conflicting_routes(
             application_route_data, istio_ingress_route_configs, all_apps_to_clear
         )
@@ -834,11 +809,6 @@ class IstioIngressCharm(CharmBase):
 
         # Synchronize external authorization configuration.
         if not self.ingress_config.is_ready() and auth_decisions_address:
-            self._set_sync_status(
-                BlockedStatus(
-                    "Ingress configuration relation missing, yet valid authentication configuration are provided."
-                )
-            )
             self._remove_gateway_resources()
             return
         self._sync_ext_authz_auth_policy(auth_decisions_address, unauthenticated_paths)
@@ -847,15 +817,11 @@ class IstioIngressCharm(CharmBase):
         # Reconcile HPA and gateway resources
 
         self._sync_gateway_resources(unique_listeners)
-        self._set_sync_status(MaintenanceStatus("Validating gateway readiness"))
         if not self._is_ready():
             return
 
         # Validate external hostname.
         if not self._ingress_url:
-            self._set_sync_status(
-                BlockedStatus("Invalid hostname provided, Please ensure this adheres to RFC 1123.")
-            )
             return
 
         # Update upstream ingress relation with current host, port, and scheme.
@@ -872,8 +838,7 @@ class IstioIngressCharm(CharmBase):
             )
         except ApiError as e:
             logger.error("Ingress sync failed: %s", e)
-            self._set_sync_status(BlockedStatus("Issue with setting up an ingress"))
-            return
+            raise e
 
         # Publish route information to ingressed applications (IPA)
         self._publish_routes_to_ingressed_applications(application_route_data)
@@ -891,8 +856,6 @@ class IstioIngressCharm(CharmBase):
                 ForwardAuthRequirerConfig(ingress_app_names=ingressed_apps)
             )
 
-        self._set_sync_status(ActiveStatus(f"Serving at {self._ingress_url}"))
-
         # Publish gateway metadata to related charms
         self._publish_gateway_metadata()
 
@@ -905,10 +868,79 @@ class IstioIngressCharm(CharmBase):
         self.on.refresh_certs.emit()
 
     def _on_collect_status(self, event: CollectStatusEvent):
-        if self._stored.are_routes_removed:
+        """Decide on the current unit status.
+
+        It calls a list of status collector functions. The collection process stops once a collector
+        returns True to prevent invalid or unneccessary checks.
+        """
+        status_collectors = [
+           self._collect_leadership_status,
+           self._collect_auth_decisions_status,
+           self._collect_route_collision_status,
+           self._collect_external_authorization_status,
+           self._collect_readiness_status,
+           self._collect_external_hostname_status,
+        ]
+        for collector in status_collectors:
+            should_stop = collector(event)
+            if should_stop:
+                break
+        event.add_status(ActiveStatus(f"Serving at {self._ingress_url}"))
+
+    def _collect_leadership_status(self, event: CollectStatusEvent):
+        """Non-leader units are considered active."""
+        if not self.unit.is_leader():
+            event.add_status(ActiveStatus("Backup unit; standing by for leader takeover"))
+            return True
+
+    def _collect_auth_decisions_status(self, event: CollectStatusEvent):
+        """Set to blocked if auth relation exists but no decisions address."""
+        auth_decisions_address = self._get_oauth_decisions_address()
+        if self.model.get_relation(FORWARD_AUTH_RELATION) and not auth_decisions_address:
+            blocked_status = BlockedStatus("Authentication configuration incomplete; ingress is disabled.")
+            event.add_status(blocked_status)
+            return True
+
+    def _collect_route_collision_status(self, event: CollectStatusEvent):
+        """Set to blocked if routes have been removed."""
+        if self._are_routes_removed():
             blocked_status = BlockedStatus("Route conflict detected. Check the logs for more information.")
             event.add_status(blocked_status)
-        event.add_status(self._get_sync_status())
+            return True
+
+    def _are_routes_removed(self) -> bool:
+        """Return if there are routes removed because of collision."""
+        ipa_http_routes = self._get_normalized_ipa_routes()
+        istio_http_routes, istio_grpc_routes = self._get_normalized_istio_routes()
+        _, http_apps_to_clear = deduplicate_http_routes(ipa_http_routes + istio_http_routes)
+        _, grpc_apps_to_clear = deduplicate_grpc_routes(istio_grpc_routes)
+        all_apps_to_clear = http_apps_to_clear | grpc_apps_to_clear
+        return len(all_apps_to_clear) > 0
+
+    def _collect_external_authorization_status(self, event: CollectStatusEvent):
+        """Block if Ingress configuration relation missing, but valid authentication configuration are provided."""
+        auth_decisions_address = self._get_oauth_decisions_address()
+        if not self.ingress_config.is_ready() and auth_decisions_address:
+            blocked_status = BlockedStatus("Ingress configuration relation missing, yet valid authentication configuration are provided.")
+            event.add_status(blocked_status)
+            return True
+
+    def _collect_readiness_status(self, event: CollectStatusEvent):
+        """Set to maintenance if not ready, or to blocked in special cases."""
+        if self._is_ready():
+            return
+        event.add_status(MaintenanceStatus("Validating gateway readiness"))
+        if not self._is_deployment_ready():
+            event.add_status(BlockedStatus("Gateway k8s deployment not ready, is istio properly installed?"))
+        if not self._is_load_balancer_ready():
+            event.add_status(BlockedStatus("Gateway load balancer is unable to obtain an IP or hostname from the cluster."))
+        return True
+
+    def _collect_external_hostname_status(self, event: CollectStatusEvent):
+        """Block on invalid external hostname."""
+        if not self._ingress_url:
+            event.add_status(BlockedStatus("Invalid hostname provided, Please ensure this adheres to RFC 1123."))
+            return True
 
     def _get_oauth_decisions_address(self) -> Optional[str]:
         """Retrieve the auth configuration decisions_address if it exists.

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,9 +54,9 @@ from lightkube.resources.core_v1 import Secret, Service
 from lightkube.types import PatchType
 from lightkube_extensions.batch import KubernetesResourceManager, create_charm_default_labels
 from lightkube_extensions.types import AuthorizationPolicy
-from ops import BlockedStatus, main
+from ops import BlockedStatus, CollectStatusEvent, StoredState, main
 from ops.charm import CharmBase
-from ops.model import ActiveStatus, MaintenanceStatus
+from ops.model import ActiveStatus, MaintenanceStatus, StatusBase
 from ops.pebble import ChangeError, Layer
 
 from models import (
@@ -156,8 +156,19 @@ PEERS_RELATION = "peers"
 class IstioIngressCharm(CharmBase):
     """Charm the service."""
 
+    _stored = StoredState()
+
     def __init__(self, *args):
         super().__init__(*args)
+
+        # display a status based on the current state
+        self._stored.set_default(
+            sync_status_name="active",
+            sync_status_message="",
+            are_routes_removed=False,
+        )
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
+
         # Add a custom event that we can emit to request a cert refresh
         self.on.define_event("refresh_certs", RefreshCerts)
 
@@ -535,13 +546,15 @@ class IstioIngressCharm(CharmBase):
 
     def _is_ready(self) -> bool:
         if not self._is_deployment_ready():
-            self.unit.status = BlockedStatus(
-                "Gateway k8s deployment not ready, is istio properly installed?"
+            self._set_sync_status(
+                BlockedStatus("Gateway k8s deployment not ready, is istio properly installed?")
             )
             return False
         if not self._is_load_balancer_ready():
-            self.unit.status = BlockedStatus(
-                "Gateway load balancer is unable to obtain an IP or hostname from the cluster."
+            self._set_sync_status(
+                BlockedStatus(
+                    "Gateway load balancer is unable to obtain an IP or hostname from the cluster."
+                )
             )
             return False
 
@@ -723,11 +736,19 @@ class IstioIngressCharm(CharmBase):
             ),
         )
 
+    def _set_sync_status(self, status: StatusBase):
+        self._stored.sync_status_name = status.name
+        self._stored.sync_status_message = status.message
+
+    def _get_sync_status(self) -> StatusBase:
+        name = self._stored.sync_status_name
+        message = self._stored.sync_status_message
+        return StatusBase.from_name(name, message)
+
     def _sync_all_resources(self):
         """Synchronize all resources including authentication, gateway, ingress, and certificates.
 
         Flow:
-        * Create a list of events (soft blockers) that do not break the flow but set a blocked state at the end.
         * Check authentication configuration.
         * Publish or clear the auth_decisions_address in ingress-config, if related.
         * If auth relation exists but no decisions address, set to blocked and remove gateway.
@@ -743,14 +764,13 @@ class IstioIngressCharm(CharmBase):
         * Set up the proxy service.
         * Update forward auth relation data with ingressed apps.
         * Request certificate inspection.
-        * Set the final status based on soft blockers.
         """
         if not self.unit.is_leader():
-            self.unit.status = ActiveStatus("Backup unit; standing by for leader takeover")
+            self._set_sync_status(ActiveStatus("Backup unit; standing by for leader takeover"))
             return
 
-        # Create a list of events (soft blockers) that do not break the flow but set a blocked state at the end.
-        soft_blockers = []
+        # reset state variable(s) related to the sync process
+        self._stored.are_routes_removed = False
 
         # Check authentication configuration.
         auth_decisions_address = self._get_oauth_decisions_address()
@@ -762,8 +782,8 @@ class IstioIngressCharm(CharmBase):
 
         # If auth relation exists but no decisions address, set to blocked and remove gateway.
         if self.model.get_relation(FORWARD_AUTH_RELATION) and not auth_decisions_address:
-            self.unit.status = BlockedStatus(
-                "Authentication configuration incomplete; ingress is disabled."
+            self._set_sync_status(
+                BlockedStatus("Authentication configuration incomplete; ingress is disabled.")
             )
             self._remove_gateway_resources()
             return
@@ -799,9 +819,7 @@ class IstioIngressCharm(CharmBase):
 
         # Clear conflicts from original structures (needed for publishing back to apps)
         all_apps_to_clear = http_apps_to_clear | grpc_apps_to_clear
-        logger.error(str(all_apps_to_clear))
-        if len(all_apps_to_clear) > 0:
-            soft_blockers.append("Route conflict detected. Check the logs for more information.")
+        self._stored.are_routes_removed = len(all_apps_to_clear) > 0
         clear_conflicting_routes(
             application_route_data, istio_ingress_route_configs, all_apps_to_clear
         )
@@ -816,8 +834,10 @@ class IstioIngressCharm(CharmBase):
 
         # Synchronize external authorization configuration.
         if not self.ingress_config.is_ready() and auth_decisions_address:
-            self.unit.status = BlockedStatus(
-                "Ingress configuration relation missing, yet valid authentication configuration are provided."
+            self._set_sync_status(
+                BlockedStatus(
+                    "Ingress configuration relation missing, yet valid authentication configuration are provided."
+                )
             )
             self._remove_gateway_resources()
             return
@@ -827,14 +847,14 @@ class IstioIngressCharm(CharmBase):
         # Reconcile HPA and gateway resources
 
         self._sync_gateway_resources(unique_listeners)
-        self.unit.status = MaintenanceStatus("Validating gateway readiness")
+        self._set_sync_status(MaintenanceStatus("Validating gateway readiness"))
         if not self._is_ready():
             return
 
         # Validate external hostname.
         if not self._ingress_url:
-            self.unit.status = BlockedStatus(
-                "Invalid hostname provided, Please ensure this adheres to RFC 1123."
+            self._set_sync_status(
+                BlockedStatus("Invalid hostname provided, Please ensure this adheres to RFC 1123.")
             )
             return
 
@@ -852,7 +872,7 @@ class IstioIngressCharm(CharmBase):
             )
         except ApiError as e:
             logger.error("Ingress sync failed: %s", e)
-            self.unit.status = BlockedStatus("Issue with setting up an ingress")
+            self._set_sync_status(BlockedStatus("Issue with setting up an ingress"))
             return
 
         # Publish route information to ingressed applications (IPA)
@@ -871,7 +891,7 @@ class IstioIngressCharm(CharmBase):
                 ForwardAuthRequirerConfig(ingress_app_names=ingressed_apps)
             )
 
-        self.unit.status = ActiveStatus(f"Serving at {self._ingress_url}")
+        self._set_sync_status(ActiveStatus(f"Serving at {self._ingress_url}"))
 
         # Publish gateway metadata to related charms
         self._publish_gateway_metadata()
@@ -884,12 +904,11 @@ class IstioIngressCharm(CharmBase):
         )
         self.on.refresh_certs.emit()
 
-        # Set the final status based on soft blockers
-        self._set_final_status(soft_blockers)
-
-    def _set_final_status(self,soft_blockers):
-        if len(soft_blockers) > 0:
-            self.unit.status = BlockedStatus(str(soft_blockers[0]))
+    def _on_collect_status(self, event: CollectStatusEvent):
+        if self._stored.are_routes_removed:
+            blocked_status = BlockedStatus("Route conflict detected. Check the logs for more information.")
+            event.add_status(blocked_status)
+        event.add_status(self._get_sync_status())
 
     def _get_oauth_decisions_address(self) -> Optional[str]:
         """Retrieve the auth configuration decisions_address if it exists.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1113,7 +1113,10 @@ class IstioIngressCharm(CharmBase):
             return True
 
     def _collect_auth_decisions_status(self, event: CollectStatusEvent):
-        """Set to blocked if auth relation exists but no decisions address."""
+        """Set to blocked if auth relation exists but no decisions address.
+
+        (Should be called on the leader unit only.)
+        """
         auth_decisions_address = self._get_oauth_decisions_address()
         if self.model.get_relation(FORWARD_AUTH_RELATION) and not auth_decisions_address:
             blocked_status = BlockedStatus("Authentication configuration incomplete; ingress is disabled.")
@@ -1121,7 +1124,10 @@ class IstioIngressCharm(CharmBase):
             return True
 
     def _collect_route_collision_status(self, event: CollectStatusEvent):
-        """Set to blocked if routes have been removed."""
+        """Set to blocked if routes have been removed.
+
+        (Should be called on the leader unit only.)
+        """
         if self._are_routes_removed():
             blocked_status = BlockedStatus("Route conflict detected. Check the logs for more information.")
             event.add_status(blocked_status)
@@ -1137,7 +1143,10 @@ class IstioIngressCharm(CharmBase):
         return len(all_apps_to_clear) > 0
 
     def _collect_external_authorization_status(self, event: CollectStatusEvent):
-        """Block if Ingress configuration relation missing, but valid authentication configuration are provided."""
+        """Block if Ingress configuration relation missing, but valid authentication configuration are provided.
+
+        (Should be called on the leader unit only.)
+        """
         auth_decisions_address = self._get_oauth_decisions_address()
         if not self.ingress_config.is_ready() and auth_decisions_address:
             blocked_status = BlockedStatus("Ingress configuration relation missing, yet valid authentication configuration are provided.")
@@ -1145,7 +1154,10 @@ class IstioIngressCharm(CharmBase):
             return True
 
     def _collect_readiness_status(self, event: CollectStatusEvent):
-        """Set to maintenance if not ready, or to blocked in special cases."""
+        """Set to maintenance if not ready, or to blocked in special cases.
+
+        (Should be called on the leader unit only.)
+        """
         if self._is_ready():
             return
         event.add_status(MaintenanceStatus("Validating gateway readiness"))
@@ -1156,7 +1168,10 @@ class IstioIngressCharm(CharmBase):
         return True
 
     def _collect_external_hostname_status(self, event: CollectStatusEvent):
-        """Block on invalid external hostname."""
+        """Block on invalid external hostname.
+
+        (Should be called on the leader unit only.)
+        """
         if not self._ingress_url:
             event.add_status(BlockedStatus("Invalid hostname provided, Please ensure this adheres to RFC 1123."))
             return True

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -144,7 +144,7 @@ def test_construct_ext_authz_policy(
 ):
     """Test that _construct_ext_authz_policy works correctly with and without unauthenticated paths."""
     # Initialize charm in test scenario
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(
             leader=True,
@@ -193,7 +193,7 @@ def test_construct_external_traffic_auth_policy(
     istio_ingress_context,
 ):
     """Test that _construct_external_traffic_auth_policy creates correct policy with IP blocks."""
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -46,7 +46,7 @@ def create_test_listeners(
 
 def test_construct_gateway(istio_ingress_charm, istio_ingress_context):
     """Assert that the Gateway definition is constructed as expected."""
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(),
     ) as manager:
@@ -396,7 +396,7 @@ def test_construct_hpa(istio_ingress_charm, istio_ingress_context):
     """Assert that the HPA definition is constructed as expected."""
     n_units = 3
     model_name = "test-model"
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(
             leader=True, planned_units=n_units, model=scenario.Model(name=model_name)

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -224,7 +224,7 @@ def test_sync_ingress_resources(
     mock_auth_manager_factory = MagicMock(return_value=mock_auth_manager)
 
     # Initialize charm in test scenario
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(
             leader=True,
@@ -318,7 +318,7 @@ def test_sync_ingress_resources_with_tls(
     mock_krm = MagicMock()
     mock_krm_factory = MagicMock(return_value=mock_krm)
 
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(
             relations=[generate_certificates_relation(subject="example.com")["relation"]],
@@ -404,7 +404,7 @@ def test_get_routes(
     istio_ingress_context,
 ):
     """Test that .get_routes returns the expected routes for given ingress relations."""
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(
             relations=ingress_relations,
@@ -626,7 +626,7 @@ def test_construct_grpc_destination_rules(istio_ingress_charm, istio_ingress_con
         },
     ]
 
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -9,7 +9,7 @@ from charms.istio_ingress_k8s.v0.istio_ingress_route import (
     RequestRedirectFilter,
     RequestRedirectSpec,
 )
-from ops import ActiveStatus
+from ops import ActiveStatus, BlockedStatus
 
 from charm import IstioIngressCharm
 from models import (
@@ -481,7 +481,7 @@ def test_get_unauthenticated_paths(application_route_data, unauthenticated_paths
 
 
 @pytest.mark.parametrize(
-    "ingress_relations, expected_ingress_data_sent",
+    "ingress_relations, expected_ingress_data_sent, expected_final_status",
     [
         # Apps related to this charm on both ingress relations
         (
@@ -498,6 +498,7 @@ def test_get_unauthenticated_paths(application_route_data, unauthenticated_paths
                 {"ingress": json.dumps({"url": "http://example.com/remote-model0-remote-app0"})},
                 {"ingress": json.dumps({"url": "http://example.com/remote-model1-remote-app1"})},
             ),
+            ActiveStatus,
         ),
         # App is related to us on multiple ingress endpoints, requiring deduplication
         (
@@ -517,6 +518,7 @@ def test_get_unauthenticated_paths(application_route_data, unauthenticated_paths
                 {},  # removed because it is a duplicate
                 {},  # removed because it is a duplicate
             ),
+            BlockedStatus,
         ),
     ],
 )
@@ -529,6 +531,7 @@ def test_ingress_e2e(
     _mock_is_ready,
     ingress_relations,
     expected_ingress_data_sent,
+    expected_final_status,
     istio_ingress_charm,
     istio_ingress_context,
 ):
@@ -558,7 +561,7 @@ def test_ingress_e2e(
     for i, relation in enumerate(ingress_relations):
         assert state_out.get_relation(relation.id).local_app_data == expected_ingress_data_sent[i]
 
-    assert isinstance(state_out.unit_status, ActiveStatus)
+    assert isinstance(state_out.unit_status, expected_final_status)
 
 
 def test_construct_grpc_destination_rules(istio_ingress_charm, istio_ingress_context):

--- a/tests/unit/test_request_auth.py
+++ b/tests/unit/test_request_auth.py
@@ -61,7 +61,7 @@ def _make_forward_auth_relation():
 
 def test_construct_request_authentication(istio_ingress_context):
     """Test that RA resource has correct targetRef, issuer, and jwksUri."""
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:
@@ -86,7 +86,7 @@ def test_construct_request_authentication(istio_ingress_context):
 
 def test_construct_deny_without_jwt_policy(istio_ingress_context):
     """Test that DENY policy uses notRequestPrincipals targeting the Gateway."""
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:
@@ -103,7 +103,7 @@ def test_construct_deny_without_jwt_policy(istio_ingress_context):
 
 def test_construct_deny_without_jwt_policy_bearer_only(istio_ingress_context):
     """Test that bearer_only=True scopes the DENY policy to Bearer-token requests."""
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:
@@ -129,7 +129,7 @@ def test_convert_to_jwt_rules(istio_ingress_context):
             forward_original_token=True,
         )
     ]
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:
@@ -155,7 +155,7 @@ def test_sync_ra_with_valid_data(mock_get_krm, istio_ingress_context):
     mock_get_krm.return_value = mock_krm
 
     relation = _make_request_auth_relation()
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(relations=[relation], leader=True),
     ) as manager:
@@ -174,7 +174,7 @@ def test_sync_ra_without_relation(mock_get_krm, istio_ingress_context):
     mock_krm = MagicMock()
     mock_get_krm.return_value = mock_krm
 
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:
@@ -191,7 +191,7 @@ def test_sync_ra_malformed_reconciles_empty(mock_get_krm, istio_ingress_context)
     mock_get_krm.return_value = mock_krm
 
     malformed_relation = _make_malformed_request_auth_relation()
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(relations=[malformed_relation], leader=True),
     ) as manager:
@@ -209,7 +209,7 @@ def test_sync_ra_mixed_creates_ra_for_valid_only(mock_get_krm, istio_ingress_con
 
     valid_relation = _make_request_auth_relation()
     malformed_relation = _make_malformed_request_auth_relation()
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(relations=[valid_relation, malformed_relation], leader=True),
     ) as manager:
@@ -233,7 +233,7 @@ def test_deny_policy_no_relation(mock_get_prm, istio_ingress_context):
     mock_prm = MagicMock()
     mock_get_prm.return_value = mock_prm
 
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True),
     ) as manager:
@@ -251,7 +251,7 @@ def test_deny_policy_valid_data_no_forward_auth(mock_get_prm, istio_ingress_cont
     mock_get_prm.return_value = mock_prm
 
     relation = _make_request_auth_relation()
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(relations=[relation], leader=True),
     ) as manager:
@@ -271,7 +271,7 @@ def test_deny_policy_malformed_data_no_forward_auth(mock_get_prm, istio_ingress_
     mock_get_prm.return_value = mock_prm
 
     malformed_relation = _make_malformed_request_auth_relation()
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(relations=[malformed_relation], leader=True),
     ) as manager:
@@ -292,7 +292,7 @@ def test_deny_policy_mixed_data_no_forward_auth(mock_get_prm, istio_ingress_cont
 
     valid_relation = _make_request_auth_relation()
     malformed_relation = _make_malformed_request_auth_relation()
-    with istio_ingress_context(
+    with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(relations=[valid_relation, malformed_relation], leader=True),
     ) as manager:


### PR DESCRIPTION
## Issue

When multiple apps requested the same ingress path, the charm only communicated the problem through log messages. A blocking status is more visible. Fixes #57.

## Solution

A list of "soft blockers" is collected during the synchronization of all resources. This final status is only set at the end to avoid breaking other functionality.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
