### PR TITLE
fix: includes all requested port listeners in the L4 policy

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -691,7 +691,7 @@ class IstioIngressCharm(CharmBase):
         )
 
     def _construct_auth_policy_from_ingress_to_target(
-        self, target_name: str, target_namespace: str, target_port: int
+        self, target_name: str, target_namespace: str, target_ports: List[int]
     ):
         """Return an AuthorizationPolicy that allows the ingress workload to communicate with the target workload."""
         return AuthorizationPolicy(
@@ -702,7 +702,7 @@ class IstioIngressCharm(CharmBase):
             spec=AuthorizationPolicySpec(
                 rules=[
                     Rule(
-                        to=[To(operation=Operation(ports=[str(target_port)]))],
+                        to=[To(operation=Operation(ports=[str(p) for p in sorted(target_ports)]))],
                         from_=[  # type: ignore # this is accessible via an alias "from"
                             # The ServiceAccount that is used to deploy the Gateway (ingress) workload
                             From(
@@ -1434,7 +1434,7 @@ class IstioIngressCharm(CharmBase):
         """Construct L4 authorization policies from normalized routes.
 
         This method is fully source-agnostic - extracts backend info from normalized routes.
-        Creates one auth policy per unique (service, port, namespace) backend.
+        Creates one auth policy per unique (service, namespace) backend, aggregating all ports.
 
         Args:
             http_routes: List of normalized HTTP routes
@@ -1443,38 +1443,27 @@ class IstioIngressCharm(CharmBase):
         Returns:
             List of AuthorizationPolicy lightkube resources
         """
-        auth_policies = []
-        seen_backends = set()
+        # Collect all ports per (service, namespace) backend
+        backend_ports: dict = {}
 
-        # Process HTTP routes - extract backends from backend_refs field
         for route in http_routes:
             for backend_ref in route["backend_refs"]:
-                backend_key = (backend_ref.name, backend_ref.port, backend_ref.namespace)
-                if backend_key not in seen_backends:
-                    seen_backends.add(backend_key)
-                    auth_policies.append(
-                        self._construct_auth_policy_from_ingress_to_target(
-                            target_name=backend_ref.name,
-                            target_namespace=backend_ref.namespace,
-                            target_port=backend_ref.port,
-                        )
-                    )
+                key = (backend_ref.name, backend_ref.namespace)
+                backend_ports.setdefault(key, set()).add(backend_ref.port)
 
-        # Process gRPC routes - extract backends from backend_refs field
         for route in grpc_routes:
             for backend_ref in route["backend_refs"]:
-                backend_key = (backend_ref.name, backend_ref.port, backend_ref.namespace)
-                if backend_key not in seen_backends:
-                    seen_backends.add(backend_key)
-                    auth_policies.append(
-                        self._construct_auth_policy_from_ingress_to_target(
-                            target_name=backend_ref.name,
-                            target_namespace=backend_ref.namespace,
-                            target_port=backend_ref.port,
-                        )
-                    )
+                key = (backend_ref.name, backend_ref.namespace)
+                backend_ports.setdefault(key, set()).add(backend_ref.port)
 
-        return auth_policies
+        return [
+            self._construct_auth_policy_from_ingress_to_target(
+                target_name=name,
+                target_namespace=namespace,
+                target_ports=list(ports),
+            )
+            for (name, namespace), ports in backend_ports.items()
+        ]
 
     def _construct_grpc_destination_rules(self, grpc_routes: List[GRPCRoute]) -> List:
         """Construct DestinationRules for gRPC backends.

--- a/tests/integration/test_charm_istio_ingress_route.py
+++ b/tests/integration/test_charm_istio_ingress_route.py
@@ -8,6 +8,7 @@ import lightkube
 import pytest
 import yaml
 from helpers import (
+    get_auth_policy_spec,
     get_ca_certificate,
     get_grpc_route_condition,
     get_http_response,
@@ -127,9 +128,27 @@ def test_http_routes_validity(juju: Juju):
     rewrite_route_condition = get_route_condition(juju.model, rewrite_route_name)
     assert rewrite_route_condition["conditions"][0]["message"] == "Route was valid"
     assert rewrite_route_condition["conditions"][0]["reason"] == "Accepted"
-    health_route_condition = get_route_condition(juju.model, health_route_name)
-    assert health_route_condition["conditions"][0]["message"] == "Route was valid"
-    assert health_route_condition["conditions"][0]["reason"] == "Accepted"
+
+    # Verify the http-9090 listener exists (extra-port-route from tester-http for multi-port testing)
+    listener_9090_condition = next(
+        (listener for listener in gateway.status["listeners"] if listener["name"] == "http-9090"),
+        None,
+    )
+    listener_9090_spec = next(
+        (listener for listener in gateway.spec["listeners"] if listener["name"] == "http-9090"),
+        None,
+    )
+    assert listener_9090_condition is not None, "Listener http-9090 not found in Gateway status"
+    assert listener_9090_spec is not None, "Listener http-9090 not found in Gateway spec"
+    assert listener_9090_condition["attachedRoutes"] == 1
+    assert listener_9090_spec["port"] == 9090
+    assert listener_9090_spec["protocol"] == "HTTP"
+
+    # Test extra-port-route on port 9090
+    extra_route_name = f"{TESTER_HTTP}-extra-port-route-httproute-http-9090-{APP_NAME}"
+    extra_route_condition = get_route_condition(juju.model, extra_route_name)
+    assert extra_route_condition["conditions"][0]["message"] == "Route was valid"
+    assert extra_route_condition["conditions"][0]["reason"] == "Accepted"
 
 
 @pytest.mark.dependency(
@@ -146,6 +165,36 @@ def test_http_routes_connectivity(juju: Juju):
     # Test /health endpoint
     health_url = f"http://{istio_ingress_address}:8080/health"
     assert send_http_request(health_url), f"Failed to reach {health_url}"
+
+
+@pytest.mark.dependency(
+    name="test_multi_port_auth_policy", depends=["test_http_routes_validity"]
+)
+def test_multi_port_auth_policy(juju: Juju):
+    """Test that a single AuthorizationPolicy is created with all ports for a multi-port backend.
+
+    The tester-http charm requests routes on ports 8080 and 9090 pointing to the same backend
+    service. The ingress charm should aggregate these into a single L4 AuthorizationPolicy
+    containing both ports, rather than creating separate policies that overwrite each other.
+    """
+    policy_name = f"{TESTER_HTTP}-{APP_NAME}-{juju.model}-l4"
+    policy_spec = get_auth_policy_spec(juju.model, policy_name)
+
+    assert policy_spec is not None, f"AuthorizationPolicy '{policy_name}' not found."
+
+    # Validate that both ports are present in a single policy
+    rules = policy_spec["rules"]
+    assert len(rules) == 1, "Expected exactly one rule in AuthorizationPolicy spec."
+
+    ports = rules[0]["to"][0]["operation"]["ports"]
+    assert sorted(ports) == ["8080", "9090"], (
+        f"Expected ports ['8080', '9090'] in AuthorizationPolicy, got {sorted(ports)}. "
+        "Multi-port aggregation may not be working correctly."
+    )
+
+    # Verify selector targets the tester-http app
+    match_labels = policy_spec["selector"]["matchLabels"]
+    assert match_labels.get("app.kubernetes.io/name") == TESTER_HTTP
 
 
 @pytest.mark.dependency(

--- a/tests/integration/testers/tester-http/src/charm.py
+++ b/tests/integration/testers/tester-http/src/charm.py
@@ -94,11 +94,15 @@ class HTTPTesterCharm(CharmBase):
         """Configure HTTP routes via istio-ingress-route."""
         # Define listener on custom port 8080
         http_listener = Listener(port=8080, protocol=ProtocolType.HTTP)
+        # Second listener on port 9090 to test multi-port auth policy aggregation.
+        # The tester does not serve on this port; we only need to verify that
+        # the ingress charm creates a single AuthorizationPolicy with both ports.
+        extra_listener = Listener(port=9090, protocol=ProtocolType.HTTP)
 
         # Configure multiple HTTP routes for testing
         config = IstioIngressRouteConfig(
             model=self.model.name,
-            listeners=[http_listener],
+            listeners=[http_listener, extra_listener],
             http_routes=[
                 # Route 1: /api path
                 HTTPRoute(
@@ -142,6 +146,17 @@ class HTTPTesterCharm(CharmBase):
                             )
                         )
                     ],
+                ),
+                # Route 4: /extra path on port 9090 — tests multi-port policy aggregation
+                HTTPRoute(
+                    name="extra-port-route",
+                    listener=extra_listener,
+                    matches=[
+                        HTTPRouteMatch(
+                            path=HTTPPathMatch(type=HTTPPathMatchType.PathPrefix, value="/extra")
+                        )
+                    ],
+                    backends=[BackendRef(service=self.app.name, port=9090)],
                 ),
             ],
         )

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -104,7 +104,7 @@ def test_construct_ingress_auth_policy(istio_ingress_charm, istio_ingress_contex
     """Test that the _construct_ingress_auth_policy method constructs an Authorization Policy object correctly."""
     target_name = "app-name"
     target_namespace = "app-namespace"
-    target_port = 80
+    target_ports = [80, 443]
 
     with istio_ingress_context(
         istio_ingress_context.on.update_status(),
@@ -114,7 +114,7 @@ def test_construct_ingress_auth_policy(istio_ingress_charm, istio_ingress_contex
         auth_policy = charm._construct_auth_policy_from_ingress_to_target(
             target_name=target_name,
             target_namespace=target_namespace,
-            target_port=target_port,
+            target_ports=target_ports,
         )
 
         # Verify the AuthorizationPolicy resource
@@ -126,7 +126,7 @@ def test_construct_ingress_auth_policy(istio_ingress_charm, istio_ingress_contex
         rule = auth_policy.spec["rules"][0]
 
         # Verify `to` field
-        assert rule["to"] == [{"operation": {"ports": ["80"]}}]
+        assert rule["to"] == [{"operation": {"ports": ["80", "443"]}}]
 
         # Verify `from` field (principals)
         principals = rule["from"][0]["source"]["principals"]
@@ -137,6 +137,149 @@ def test_construct_ingress_auth_policy(istio_ingress_charm, istio_ingress_contex
         assert auth_policy.spec["selector"] == {
             "matchLabels": {"app.kubernetes.io/name": "app-name"}
         }
+
+
+def test_construct_auth_policies_multi_port_aggregation(istio_ingress_charm, istio_ingress_context):
+    """Test that _construct_auth_policies aggregates multiple ports for the same backend into a single policy."""
+    # Create routes that simulate the Tempo scenario: same service, different ports
+    http_routes = [
+        HTTPRoute(
+            name="tempo-api",
+            listener_port=80,
+            listener_protocol="HTTP",
+            namespace="cos",
+            source_app="tempo",
+            source_relation="istio-ingress-route",
+            matches=[
+                HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/tempo-api"))
+            ],
+            backend_refs=[BackendRef(name="tempo", port=3200, namespace="cos")],
+            filters=[],
+        ),
+        HTTPRoute(
+            name="tempo-otlp-http",
+            listener_port=80,
+            listener_protocol="HTTP",
+            namespace="cos",
+            source_app="tempo",
+            source_relation="istio-ingress-route",
+            matches=[
+                HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/tempo-otlp"))
+            ],
+            backend_refs=[BackendRef(name="tempo", port=4318, namespace="cos")],
+            filters=[],
+        ),
+        HTTPRoute(
+            name="tempo-zipkin",
+            listener_port=80,
+            listener_protocol="HTTP",
+            namespace="cos",
+            source_app="tempo",
+            source_relation="istio-ingress-route",
+            matches=[
+                HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/tempo-zipkin"))
+            ],
+            backend_refs=[BackendRef(name="tempo", port=9411, namespace="cos")],
+            filters=[],
+        ),
+        # A different service in the same namespace with a single port
+        HTTPRoute(
+            name="grafana-route",
+            listener_port=80,
+            listener_protocol="HTTP",
+            namespace="cos",
+            source_app="grafana",
+            source_relation="istio-ingress-route",
+            matches=[
+                HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/grafana"))
+            ],
+            backend_refs=[BackendRef(name="grafana", port=3000, namespace="cos")],
+            filters=[],
+        ),
+    ]
+
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(),
+    ) as manager:
+        charm: IstioIngressCharm = manager.charm
+        auth_policies = charm._construct_auth_policies(http_routes=http_routes, grpc_routes=[])
+
+        # Should produce exactly 2 policies: one for tempo (3 ports aggregated), one for grafana
+        assert len(auth_policies) == 2
+
+        # Find the tempo policy
+        tempo_policy = next(
+            p for p in auth_policies
+            if p.metadata.name == f"tempo-{charm.app.name}-cos-l4"
+        )
+        # All 3 ports should be aggregated into a single policy
+        tempo_ports = tempo_policy.spec["rules"][0]["to"][0]["operation"]["ports"]
+        assert sorted(tempo_ports) == ["3200", "4318", "9411"]
+
+        # Find the grafana policy
+        grafana_policy = next(
+            p for p in auth_policies
+            if p.metadata.name == f"grafana-{charm.app.name}-cos-l4"
+        )
+        grafana_ports = grafana_policy.spec["rules"][0]["to"][0]["operation"]["ports"]
+        assert grafana_ports == ["3000"]
+
+        # Verify both policies have correct namespace and selector
+        assert tempo_policy.metadata.namespace == "cos"
+        assert tempo_policy.spec["selector"]["matchLabels"]["app.kubernetes.io/name"] == "tempo"
+        assert grafana_policy.metadata.namespace == "cos"
+        assert grafana_policy.spec["selector"]["matchLabels"]["app.kubernetes.io/name"] == "grafana"
+
+
+def test_construct_auth_policies_mixed_http_grpc(istio_ingress_charm, istio_ingress_context):
+    """Test that _construct_auth_policies aggregates ports across HTTP and gRPC routes for the same backend."""
+    from models import GRPCMethodMatch, GRPCRouteMatch
+
+    http_routes = [
+        HTTPRoute(
+            name="myapp-http",
+            listener_port=80,
+            listener_protocol="HTTP",
+            namespace="test-ns",
+            source_app="myapp",
+            source_relation="istio-ingress-route",
+            matches=[
+                HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/myapp"))
+            ],
+            backend_refs=[BackendRef(name="myapp", port=8080, namespace="test-ns")],
+            filters=[],
+        ),
+    ]
+    grpc_routes = [
+        {
+            "name": "myapp-grpc",
+            "listener_port": 9000,
+            "listener_protocol": "HTTP",
+            "namespace": "test-ns",
+            "source_app": "myapp",
+            "source_relation": "istio-ingress-route",
+            "matches": [
+                GRPCRouteMatch(method=GRPCMethodMatch(service="myapp.Service", method="Call"))
+            ],
+            "backend_refs": [BackendRef(name="myapp", port=9000, namespace="test-ns")],
+            "filters": [],
+        },
+    ]
+
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(),
+    ) as manager:
+        charm: IstioIngressCharm = manager.charm
+        auth_policies = charm._construct_auth_policies(
+            http_routes=http_routes, grpc_routes=grpc_routes
+        )
+
+        # Same backend (myapp, test-ns) from both HTTP and gRPC → single policy with both ports
+        assert len(auth_policies) == 1
+        ports = auth_policies[0].spec["rules"][0]["to"][0]["operation"]["ports"]
+        assert sorted(ports) == ["8080", "9000"]
 
 
 def generate_ingress_relation_data(


### PR DESCRIPTION
## Issue
Fixes #160 


## Solution
Include all requested port listeners requested by the downstream application in the L4 policy constructed in the charm


## Context
The `istio-ingress-route` interface allowed the downstream application request more than one port listener. And the L4 policy creation was logic was only covering the case where we had a single fix listener port. This PR addresses this gap.


## Testing Instructions
Follow the itests for the `istio-ingress-route` interface or test with the [tempo](https://github.com/canonical/tempo-operators) charm