### PR TITLE
fix: extends default include headers with all standard headers

### DIFF
--- a/lib/charms/istio_k8s/v0/istio_ingress_config.py
+++ b/lib/charms/istio_k8s/v0/istio_ingress_config.py
@@ -91,7 +91,15 @@ LIBID = "12331b5ac41547e087edd7ac993176ed"
 # Default headers for external authorization.
 # These defaults are based on oauth2-proxy requirements and can be used by ingress charms
 # when no headers are provided by the auth provider.
-DEFAULT_INCLUDE_HEADERS_IN_CHECK = ["authorization", "cookie"]
+DEFAULT_INCLUDE_HEADERS_IN_CHECK = [
+    "authorization",
+    "cookie",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-forwarded-uri",
+    "x-forwarded-prefix",
+]
 DEFAULT_HEADERS_TO_UPSTREAM_ON_ALLOW = [
     "authorization",
     "path",


### PR DESCRIPTION
## Issue
The standard headers included for forward authentication does not include all the standard headers that would be required by the proxy auth. This PR extends the default with required default headers for oauth2-proxy to be able to work with istio-ingress-k8s when istio ingress is behind an outer ingress.