### PR TITLE
fix: include icon.svg in the final charm file

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,11 @@ parts:
     override-build: |
       craftctl default
       git describe --always > $CRAFT_PART_INSTALL/version
+  icon:
+    plugin: dump
+    source: .
+    stage:
+      - icon.svg
 
 charm-libs:
   - lib: "tls_certificates_interface.tls_certificates"


### PR DESCRIPTION
The icon file must be explicitly referenced to be included in the final .charm file.