### PR TITLE
chore: utils.py refactoring

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,6 @@ from canonical_service_mesh.k8s.resource_manager import (
 from canonical_service_mesh.k8s.types.istio import AuthorizationPolicy
 from canonical_service_mesh.models import (
     AllowedRoutes,
-    GatewayTLSConfig,
     GRPCRouteResource,
     GRPCRouteResourceSpec,
     GRPCRouteRule,
@@ -39,7 +38,6 @@ from canonical_service_mesh.models import (
     Listener,
     Metadata,
     ParentRef,
-    SecretObjectReference,
 )
 from canonical_service_mesh.models.istio import (
     AuthorizationPolicySpec,

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,9 +27,6 @@ from canonical_service_mesh.k8s.resource_manager import (
 from canonical_service_mesh.k8s.types.istio import AuthorizationPolicy
 from canonical_service_mesh.models import (
     AllowedRoutes,
-    GRPCRouteResource,
-    GRPCRouteResourceSpec,
-    GRPCRouteRule,
     IstioGatewayResource,
     IstioGatewaySpec,
     Listener,
@@ -1413,31 +1410,11 @@ class IstioIngressCharm(CharmBase):
 
         for route in grpc_routes:
             # Derive listener name from Gateway protocol and port
-            listener_name = f"{route['listener_protocol'].lower()}-{route['listener_port']}"
+            listener_name = f"{route.listener_protocol.lower()}-{route.listener_port}"
 
             # Construct GRPCRoute resource from normalized data
-            grpc_route_resource = GRPCRouteResource(
-                metadata=Metadata(
-                    name=route["name"],
-                    namespace=route["namespace"],
-                ),
-                spec=GRPCRouteResourceSpec(
-                    parentRefs=[
-                        ParentRef(
-                            name=self.app.name,
-                            namespace=self.model.name,
-                            sectionName=listener_name,
-                        )
-                    ],
-                    rules=[
-                        GRPCRouteRule(
-                            matches=route["matches"],  # Already charm GRPCRouteMatch models
-                            backendRefs=route["backend_refs"],  # Already charm BackendRef models
-                            filters=route["filters"] if route["filters"] else None,
-                        )
-                    ],
-                ),
-            )
+            grpc_route_resource = route.resource
+            grpc_route_resource.spec.parentRefs = [ParentRef(name=self.app.name,namespace=self.model.name,sectionName=listener_name)]
 
             # Convert to lightkube resource
             grpcroute_lk_resource = RESOURCE_TYPES["GRPCRoute"]
@@ -1476,7 +1453,9 @@ class IstioIngressCharm(CharmBase):
                 backend_ports.setdefault(key, set()).add(backend_ref.port)
 
         for route in grpc_routes:
-            for backend_ref in route["backend_refs"]:
+            backend_refs = route.resource.spec.rules[0].backendRefs
+            assert backend_refs is not None
+            for backend_ref in backend_refs:
                 key = (backend_ref.name, backend_ref.namespace)
                 backend_ports.setdefault(key, set()).add(backend_ref.port)
 
@@ -1505,7 +1484,9 @@ class IstioIngressCharm(CharmBase):
         seen_backends = set()
 
         for route in grpc_routes:
-            for backend_ref in route["backend_refs"]:
+            backend_refs = route.resource.spec.rules[0].backendRefs
+            assert backend_refs is not None
+            for backend_ref in backend_refs:
                 # One DR per unique (service, namespace) - not per port
                 backend_key = (backend_ref.name, backend_ref.namespace)
                 if backend_key not in seen_backends:

--- a/src/charm.py
+++ b/src/charm.py
@@ -635,11 +635,12 @@ class IstioIngressCharm(CharmBase):
             listener_name = f"{norm_listener.protocol.lower()}-{norm_listener.port}"
 
             # replace old placeholder values
-            norm_listener.name = listener_name
-            norm_listener.allowedRoutes = allowed_routes
-            norm_listener.hostname = hostname
-
-            listeners.append(norm_listener)
+            final_listener = norm_listener.model_copy(deep=True,update={
+                "name": listener_name,
+                "allowedRoutes": allowed_routes,
+                "hostname": hostname,
+            })
+            listeners.append(final_listener)
 
         gateway = IstioGatewayResource(
             metadata=Metadata(
@@ -1381,7 +1382,7 @@ class IstioIngressCharm(CharmBase):
         for route in http_routes:
             # Derive listener name from Gateway protocol and port
             listener_name = f"{route.listener_protocol.lower()}-{route.listener_port}"
-            http_route_resource = route.resource
+            http_route_resource = route.resource.model_copy(deep=True)
             http_route_resource.spec.parentRefs = [ParentRef(name=self.app.name,namespace=self.model.name,sectionName=listener_name)]
 
             # Convert to lightkube resource
@@ -1413,7 +1414,7 @@ class IstioIngressCharm(CharmBase):
             listener_name = f"{route.listener_protocol.lower()}-{route.listener_port}"
 
             # Construct GRPCRoute resource from normalized data
-            grpc_route_resource = route.resource
+            grpc_route_resource = route.resource.model_copy(deep=True)
             grpc_route_resource.spec.parentRefs = [ParentRef(name=self.app.name,namespace=self.model.name,sectionName=listener_name)]
 
             # Convert to lightkube resource

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,9 +30,6 @@ from canonical_service_mesh.models import (
     GRPCRouteResource,
     GRPCRouteResourceSpec,
     GRPCRouteRule,
-    HTTPRouteResource,
-    HTTPRouteResourceSpec,
-    HTTPRouteRule,
     IstioGatewayResource,
     IstioGatewaySpec,
     Listener,
@@ -1386,31 +1383,9 @@ class IstioIngressCharm(CharmBase):
 
         for route in http_routes:
             # Derive listener name from Gateway protocol and port
-            listener_name = f"{route['listener_protocol'].lower()}-{route['listener_port']}"
-
-            # Construct HTTPRoute resource from normalized data
-            http_route_resource = HTTPRouteResource(
-                metadata=Metadata(
-                    name=route["name"],
-                    namespace=route["namespace"],
-                ),
-                spec=HTTPRouteResourceSpec(
-                    parentRefs=[
-                        ParentRef(
-                            name=self.app.name,
-                            namespace=self.model.name,
-                            sectionName=listener_name,
-                        )
-                    ],
-                    rules=[
-                        HTTPRouteRule(
-                            matches=route["matches"],  # Already charm HTTPRouteMatch models
-                            backendRefs=route["backend_refs"],  # Already charm BackendRef models
-                            filters=route["filters"] if route["filters"] else None,
-                        )
-                    ],
-                ),
-            )
+            listener_name = f"{route.listener_protocol.lower()}-{route.listener_port}"
+            http_route_resource = route.resource
+            http_route_resource.spec.parentRefs = [ParentRef(name=self.app.name,namespace=self.model.name,sectionName=listener_name)]
 
             # Convert to lightkube resource
             httproute_lk_resource = RESOURCE_TYPES["HTTPRoute"]
@@ -1494,7 +1469,9 @@ class IstioIngressCharm(CharmBase):
         backend_ports: dict = {}
 
         for route in http_routes:
-            for backend_ref in route["backend_refs"]:
+            backend_refs = route.resource.spec.rules[0].backendRefs
+            assert backend_refs is not None
+            for backend_ref in backend_refs:
                 key = (backend_ref.name, backend_ref.namespace)
                 backend_ports.setdefault(key, set()).add(backend_ref.port)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,12 +26,12 @@ from canonical_service_mesh.k8s.resource_manager import (
 )
 from canonical_service_mesh.k8s.types.istio import AuthorizationPolicy
 from canonical_service_mesh.models import (
-    AllowedRoutes,
+    GRPCRouteResource,
+    HTTPRouteResource,
     IstioGatewayResource,
     IstioGatewaySpec,
     Listener,
     Metadata,
-    ParentRef,
 )
 from canonical_service_mesh.models.istio import (
     AuthorizationPolicySpec,
@@ -87,8 +87,6 @@ from utils import (
     ISTIO_INGRESS_ROUTE_AUTHENTICATED_NAME,
     ISTIO_INGRESS_ROUTE_UNAUTHENTICATED_NAME,
     DisabledCertHandler,
-    GRPCRoute,
-    HTTPRoute,
     RefreshCerts,
     RouteInfo,
     clear_conflicting_routes,
@@ -624,23 +622,8 @@ class IstioIngressCharm(CharmBase):
         Returns:
             Gateway lightkube resource
         """
-        allowed_routes = AllowedRoutes(namespaces={"from": "All"})
         # Use local gateway address for the K8s Gateway resource hostname,
         # not the cascaded upstream address
-        hostname = self._local_gateway_address if self._is_valid_hostname(self._local_gateway_address) else None
-
-        listeners = []
-        for norm_listener in normalized_listeners:
-            # Derive listener name from Gateway protocol and port
-            listener_name = f"{norm_listener.protocol.lower()}-{norm_listener.port}"
-
-            # replace old placeholder values
-            final_listener = norm_listener.model_copy(deep=True,update={
-                "name": listener_name,
-                "allowedRoutes": allowed_routes,
-                "hostname": hostname,
-            })
-            listeners.append(final_listener)
 
         gateway = IstioGatewayResource(
             metadata=Metadata(
@@ -650,7 +633,7 @@ class IstioIngressCharm(CharmBase):
             ),
             spec=IstioGatewaySpec(
                 gatewayClassName="istio",
-                listeners=listeners,
+                listeners=normalized_listeners,
             ),
         )
         gateway_resource = RESOURCE_TYPES["Gateway"]
@@ -774,21 +757,21 @@ class IstioIngressCharm(CharmBase):
     def _is_tls_enabled(self) -> bool:
         return self._construct_gateway_tls_secret() is not None
 
-    def _get_normalized_istio_routes(self) -> Tuple[List[HTTPRoute],List[GRPCRoute]]:
+    def _get_normalized_istio_routes(self) -> Tuple[List[HTTPRouteResource],List[GRPCRouteResource]]:
         """Return the normalized Istio routes."""
         is_tls_enabled = self._is_tls_enabled()
         istio_ingress_route_configs = self._get_istio_ingress_route_configs()
         istio_http_routes = normalize_istio_ingress_route_http_routes(
-            istio_ingress_route_configs, is_tls_enabled, self.app.name
+            istio_ingress_route_configs, is_tls_enabled, self.app.name, self.model.name
         )
         istio_grpc_routes = normalize_istio_ingress_route_grpc_routes(
-            istio_ingress_route_configs, is_tls_enabled, self.app.name
+            istio_ingress_route_configs, is_tls_enabled, self.app.name, self.model.name
         )
         return istio_http_routes, istio_grpc_routes
 
-    def _get_normalized_ipa_routes(self) -> List[HTTPRoute]:
+    def _get_normalized_ipa_routes(self) -> List[HTTPRouteResource]:
         """Return the normalized IPA routes from both sources."""
-        return normalize_ipa_routes(self._get_routes(), self._is_tls_enabled(), self.app.name)
+        return normalize_ipa_routes(self._get_routes(), self._is_tls_enabled(), self.app.name, self.model.name)
 
     def _convert_to_jwt_rules(self, interface_jwt_rules: list) -> List[JWTRule]:
         """Convert interface JWTRule models to Istio CRD JWTRule models."""
@@ -928,6 +911,21 @@ class IstioIngressCharm(CharmBase):
 
         policy_manager.reconcile(policies=[], mesh_type=MeshType.istio, raw_policies=resources)
 
+
+    def _get_hostname_from_local_gateway_address(self) -> Optional[str]:
+        """Hostname based on the local gateway address."""
+        return self._local_gateway_address if self._is_valid_hostname(self._local_gateway_address) else None
+
+
+    def _get_all_listeners(self,tls_secret_name: Optional[str], istio_ingress_route_configs: Dict) -> Tuple[List[Listener],List[Listener]]:
+        """Return IPA and istio-ingress-route listeners."""
+        hostname = self._get_hostname_from_local_gateway_address()
+        ipa_listeners: List[Listener] = normalize_ipa_listeners(tls_secret_name,hostname)
+        istio_listeners: List[Listener] = normalize_istio_ingress_route_listeners(
+            istio_ingress_route_configs, tls_secret_name, hostname
+        )
+        return ipa_listeners, istio_listeners
+
     def _sync_all_resources(self) -> None:
         """Synchronize all resources including authentication, gateway, ingress, and certificates.
 
@@ -972,10 +970,7 @@ class IstioIngressCharm(CharmBase):
         tls_secret_name = self._certificate_secret_name if self._is_tls_enabled() else None
 
         # Normalize listeners from both sources
-        ipa_listeners: List[Listener] = normalize_ipa_listeners(tls_secret_name)
-        istio_listeners: List[Listener] = normalize_istio_ingress_route_listeners(
-            istio_ingress_route_configs, tls_secret_name
-        )
+        ipa_listeners, istio_listeners = self._get_all_listeners(tls_secret_name,istio_ingress_route_configs)
 
         # Normalize routes from both sources
         ipa_http_routes = self._get_normalized_ipa_routes()
@@ -1366,7 +1361,7 @@ class IstioIngressCharm(CharmBase):
         # Without MERGE, Server-Side Apply accumulates stale listeners and preserves omitted fields.
         krm.reconcile(resources_list, patch_type=PatchType.MERGE)
 
-    def _construct_httproutes(self, http_routes: List[HTTPRoute]) -> List:
+    def _construct_httproutes(self, http_routes: List[HTTPRouteResource]) -> List:
         """Construct HTTPRoute K8s resources from normalized HTTP routes.
 
         This method is fully source-agnostic - normalized data already contains charm models.
@@ -1380,23 +1375,18 @@ class IstioIngressCharm(CharmBase):
         httproutes = []
 
         for route in http_routes:
-            # Derive listener name from Gateway protocol and port
-            listener_name = f"{route.listener_protocol.lower()}-{route.listener_port}"
-            http_route_resource = route.resource.model_copy(deep=True)
-            http_route_resource.spec.parentRefs = [ParentRef(name=self.app.name,namespace=self.model.name,sectionName=listener_name)]
-
             # Convert to lightkube resource
             httproute_lk_resource = RESOURCE_TYPES["HTTPRoute"]
             httproutes.append(
                 httproute_lk_resource(
-                    metadata=ObjectMeta.from_dict(http_route_resource.metadata.model_dump()),
-                    spec=http_route_resource.spec.model_dump(exclude_none=True),
+                    metadata=ObjectMeta.from_dict(route.metadata.model_dump()),
+                    spec=route.spec.model_dump(exclude_none=True),
                 )
             )
 
         return httproutes
 
-    def _construct_grpcroutes(self, grpc_routes: List[GRPCRoute]) -> List:
+    def _construct_grpcroutes(self, grpc_routes: List[GRPCRouteResource]) -> List:
         """Construct GRPCRoute K8s resources from normalized gRPC routes.
 
         This method is fully source-agnostic - normalized data already contains charm models.
@@ -1410,26 +1400,19 @@ class IstioIngressCharm(CharmBase):
         grpcroutes = []
 
         for route in grpc_routes:
-            # Derive listener name from Gateway protocol and port
-            listener_name = f"{route.listener_protocol.lower()}-{route.listener_port}"
-
-            # Construct GRPCRoute resource from normalized data
-            grpc_route_resource = route.resource.model_copy(deep=True)
-            grpc_route_resource.spec.parentRefs = [ParentRef(name=self.app.name,namespace=self.model.name,sectionName=listener_name)]
-
             # Convert to lightkube resource
             grpcroute_lk_resource = RESOURCE_TYPES["GRPCRoute"]
             grpcroutes.append(
                 grpcroute_lk_resource(
-                    metadata=ObjectMeta.from_dict(grpc_route_resource.metadata.model_dump()),
-                    spec=grpc_route_resource.spec.model_dump(exclude_none=True),
+                    metadata=ObjectMeta.from_dict(route.metadata.model_dump()),
+                    spec=route.spec.model_dump(exclude_none=True),
                 )
             )
 
         return grpcroutes
 
     def _construct_auth_policies(
-        self, http_routes: List[HTTPRoute], grpc_routes: List[GRPCRoute]
+        self, http_routes: List[HTTPRouteResource], grpc_routes: List[GRPCRouteResource]
     ) -> List:
         """Construct L4 authorization policies from normalized routes.
 
@@ -1447,14 +1430,14 @@ class IstioIngressCharm(CharmBase):
         backend_ports: dict = {}
 
         for route in http_routes:
-            backend_refs = route.resource.spec.rules[0].backendRefs
+            backend_refs = route.spec.rules[0].backendRefs
             assert backend_refs is not None
             for backend_ref in backend_refs:
                 key = (backend_ref.name, backend_ref.namespace)
                 backend_ports.setdefault(key, set()).add(backend_ref.port)
 
         for route in grpc_routes:
-            backend_refs = route.resource.spec.rules[0].backendRefs
+            backend_refs = route.spec.rules[0].backendRefs
             assert backend_refs is not None
             for backend_ref in backend_refs:
                 key = (backend_ref.name, backend_ref.namespace)
@@ -1469,7 +1452,7 @@ class IstioIngressCharm(CharmBase):
             for (name, namespace), ports in backend_ports.items()
         ]
 
-    def _construct_grpc_destination_rules(self, grpc_routes: List[GRPCRoute]) -> List:
+    def _construct_grpc_destination_rules(self, grpc_routes: List[GRPCRouteResource]) -> List:
         """Construct DestinationRules for gRPC backends.
 
         Creates one DestinationRule per unique (service, namespace) backend
@@ -1485,7 +1468,7 @@ class IstioIngressCharm(CharmBase):
         seen_backends = set()
 
         for route in grpc_routes:
-            backend_refs = route.resource.spec.rules[0].backendRefs
+            backend_refs = route.spec.rules[0].backendRefs
             assert backend_refs is not None
             for backend_ref in backend_refs:
                 # One DR per unique (service, namespace) - not per port
@@ -1520,7 +1503,7 @@ class IstioIngressCharm(CharmBase):
 
         return destination_rules
 
-    def _sync_ingress_resources(self, http_routes: List[HTTPRoute], grpc_routes: List[GRPCRoute]):
+    def _sync_ingress_resources(self, http_routes: List[HTTPRouteResource], grpc_routes: List[GRPCRouteResource]):
         """Synchronize all ingress resources (HTTPRoutes, GRPCRoutes, and L4 auth policies) from normalized data.
 
         This method works on normalized, deduplicated routes from all sources (IPA and istio-ingress-route).

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,7 +95,6 @@ from utils import (
     ISTIO_INGRESS_ROUTE_AUTHENTICATED_NAME,
     ISTIO_INGRESS_ROUTE_UNAUTHENTICATED_NAME,
     DisabledCertHandler,
-    GatewayListener,
     GRPCRoute,
     HTTPRoute,
     RefreshCerts,
@@ -617,7 +616,7 @@ class IstioIngressCharm(CharmBase):
             },
         )
 
-    def _construct_gateway(self, normalized_listeners: List[GatewayListener]):
+    def _construct_gateway(self, normalized_listeners: List[Listener]):
         """Construct the Gateway resource from normalized listeners.
 
         This method constructs a Gateway from a list of normalized listeners that have already
@@ -641,23 +640,14 @@ class IstioIngressCharm(CharmBase):
         listeners = []
         for norm_listener in normalized_listeners:
             # Derive listener name from Gateway protocol and port
-            listener_name = f"{norm_listener['gateway_protocol'].lower()}-{norm_listener['port']}"
+            listener_name = f"{norm_listener.protocol.lower()}-{norm_listener.port}"
 
-            listener = Listener(
-                name=listener_name,
-                port=norm_listener["port"],
-                protocol=norm_listener["gateway_protocol"],
-                allowedRoutes=allowed_routes,
-                hostname=hostname,
-            )
+            # replace old placeholder values
+            norm_listener.name = listener_name
+            norm_listener.allowedRoutes = allowed_routes
+            norm_listener.hostname = hostname
 
-            # Add TLS config if this is an HTTPS listener
-            if norm_listener["gateway_protocol"] == "HTTPS" and norm_listener["tls_secret_name"]:
-                listener.tls = GatewayTLSConfig(
-                    certificateRefs=[SecretObjectReference(name=norm_listener["tls_secret_name"])]
-                )
-
-            listeners.append(listener)
+            listeners.append(norm_listener)
 
         gateway = IstioGatewayResource(
             metadata=Metadata(
@@ -945,7 +935,7 @@ class IstioIngressCharm(CharmBase):
 
         policy_manager.reconcile(policies=[], mesh_type=MeshType.istio, raw_policies=resources)
 
-    def _sync_all_resources(self):
+    def _sync_all_resources(self) -> None:
         """Synchronize all resources including authentication, gateway, ingress, and certificates.
 
         Flow:
@@ -989,8 +979,8 @@ class IstioIngressCharm(CharmBase):
         tls_secret_name = self._certificate_secret_name if self._is_tls_enabled() else None
 
         # Normalize listeners from both sources
-        ipa_listeners = normalize_ipa_listeners(tls_secret_name)
-        istio_listeners = normalize_istio_ingress_route_listeners(
+        ipa_listeners: List[Listener] = normalize_ipa_listeners(tls_secret_name)
+        istio_listeners: List[Listener] = normalize_istio_ingress_route_listeners(
             istio_ingress_route_configs, tls_secret_name
         )
 
@@ -1354,7 +1344,7 @@ class IstioIngressCharm(CharmBase):
         resources = [self._construct_external_traffic_auth_policy(ip_blocks)]
         policy_manager.reconcile(policies=[], mesh_type=MeshType.istio, raw_policies=resources)
 
-    def _sync_gateway_resources(self, normalized_listeners: List[GatewayListener]):
+    def _sync_gateway_resources(self, normalized_listeners: List[Listener]):
         """Synchronize Gateway resources using normalized listeners.
 
         Args:

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,6 +28,7 @@ from canonical_service_mesh.models import (
     HTTPRouteRule,
     Listener,
     Metadata,
+    ParentRef,
     SecretObjectReference,
 )
 from charmlibs.interfaces.istio_ingress_route import (
@@ -40,7 +41,6 @@ from charmlibs.interfaces.istio_ingress_route import (
     to_gateway_protocol,
 )
 from ops import EventBase
-from pydantic import BaseModel
 
 HTTPRouteFilter = URLRewriteFilter | RequestRedirectFilter
 GRPCRouteFilter = RequestRedirectFilter
@@ -55,7 +55,10 @@ INGRESS_AUTHENTICATED_NAME = "ingress"
 INGRESS_UNAUTHENTICATED_NAME = "ingress-unauthenticated"
 ISTIO_INGRESS_ROUTE_AUTHENTICATED_NAME = "istio-ingress-route"
 ISTIO_INGRESS_ROUTE_UNAUTHENTICATED_NAME = "istio-ingress-route-unauthenticated"
-
+ROUTE_LISTENER_PORT_LABEL = "istio-ingress.juju.is/listener_port"
+ROUTE_LISTENER_PROTOCOL_LABEL = "istio-ingress.juju.is/listener_protocol"
+ROUTE_SOURCE_APP_LABEL = "istio-ingress.juju.is/source_app"
+ROUTE_SOURCE_RELATION_LABEL = "istio-ingress.juju.is/source_relation"
 
 # ============================================================================
 # Exception Classes
@@ -89,52 +92,28 @@ class RouteInfo(TypedDict):
     prefix: Optional[str]
 
 
-class HTTPRoute(BaseModel):
-    """Normalized HTTPRoute data structure.
-
-    All fields use charm models from models.py (K8s Gateway API format).
-    """
-
-    resource: HTTPRouteResource
-    source_app: str
-    source_relation: str
-    listener_port: int
-    listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
-
-
-class GRPCRoute(BaseModel):
-    """Normalized GRPCRoute data structure.
-
-    All fields use charm models from models.py (K8s Gateway API format).
-    """
-
-    resource: GRPCRouteResource
-    listener_port: int
-    listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
-    source_app: str
-    source_relation: str
-
-
 # ============================================================================
 # Adapters
 # ============================================================================
-def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[Listener]:
+def normalize_ipa_listeners(tls_secret_name: Optional[str], hostname: Optional[str]) -> List[Listener]:
     """Normalize IPA listeners to common format.
 
     IPA always uses standard ports: 80 for HTTP, 443 for HTTPS.
 
     Args:
         tls_secret_name: Name of TLS secret if TLS is enabled
+        hostname: the hostname to be used with the generated Listeners
 
     Returns:
         List of normalized listeners (http-80, and https-443 if TLS enabled)
     """
     listeners: List[Listener] = [
         Listener(
-            name="",
+            name="http-80",
             port=80,
             protocol="HTTP",
-            allowedRoutes=AllowedRoutes(namespaces={}),
+            allowedRoutes=AllowedRoutes(namespaces={"from": "All"}),
+            hostname=hostname,
             tls=None,
         )
     ]
@@ -145,8 +124,9 @@ def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[Listener]:
                 name="",
                 port=443,
                 protocol="HTTPS",
-                allowedRoutes=AllowedRoutes(namespaces={}),
-                tls=create_gateway_tls_config(tls_secret_name) # tls_secret_name,
+                allowedRoutes=AllowedRoutes(namespaces={"from": "All"}),
+                hostname=hostname,
+                tls=create_gateway_tls_config(tls_secret_name)
             )
         )
 
@@ -154,13 +134,14 @@ def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[Listener]:
 
 
 def normalize_istio_ingress_route_listeners(
-    istio_ingress_route_configs: dict, tls_secret_name: Optional[str]
+    istio_ingress_route_configs: dict, tls_secret_name: Optional[str], hostname: Optional[str]
 ) -> List[Listener]:
     """Normalize istio-ingress-route listeners to common format.
 
     Args:
         istio_ingress_route_configs: Dict mapping (app_name, relation_name) to config data
         tls_secret_name: Name of TLS secret if TLS is enabled
+        hostname: the hostname to be used with the generated Listeners
 
     Returns:
         List of normalized listeners
@@ -187,9 +168,9 @@ def normalize_istio_ingress_route_listeners(
                     name="",
                     port=listener.port,
                     protocol=gateway_protocol,
-                    allowedRoutes=AllowedRoutes(namespaces={}),
+                    allowedRoutes=AllowedRoutes(namespaces={"from": "All"}),
+                    hostname=hostname,
                     tls=tls_config,
-                    # source_app=app_name,
                 )
             )
 
@@ -203,7 +184,8 @@ def _create_http_redirect_route(
     source_app: str,
     source_relation: str,
     ingress_app_name: str,
-) -> HTTPRoute:
+    ingress_model_name: str
+) -> HTTPRouteResource:
     """Create an HTTP->HTTPS redirect route between the standard http-80 and https-443 listeners.
 
     Args:
@@ -213,6 +195,7 @@ def _create_http_redirect_route(
         source_app: Source application name
         source_relation: Source relation name
         ingress_app_name: Name of the ingress charm app
+        ingress_model_name: Name of the ingress charm's model
 
     Returns:
         HTTPRoute with RequestRedirect filter
@@ -227,33 +210,35 @@ def _create_http_redirect_route(
         )  # https redirection without port spec will always redirect to the standard 443 port.
     )
 
-    return HTTPRoute(
-        resource=HTTPRouteResource(
-                metadata=Metadata(
-                    name=route_name,
-                    namespace=namespace,
-                ),
-                spec=HTTPRouteResourceSpec(
-                    parentRefs=[], # Maybe encode remaining fields here
-                    rules=[
-                        HTTPRouteRule(
-                            matches=[HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value=prefix))],  # Already charm HTTPRouteMatch models
-                            backendRefs=[],  # No backends for redirect routes
-                            filters=filters,
-                        )
-                    ],
-                ),
-            ),
-        listener_port=80,
-        listener_protocol="HTTP",
-        source_app=source_app,
-        source_relation=source_relation,
+    return HTTPRouteResource(
+        metadata=Metadata(
+            name=route_name,
+            namespace=namespace,
+            labels={
+                ROUTE_LISTENER_PORT_LABEL: "80",
+                ROUTE_LISTENER_PROTOCOL_LABEL: "HTTP",
+                ROUTE_SOURCE_APP_LABEL: source_app,
+                ROUTE_SOURCE_RELATION_LABEL: source_relation
+            }
+        ),
+        spec=HTTPRouteResourceSpec(
+            parentRefs=[
+                ParentRef(name=ingress_app_name,namespace=ingress_model_name,sectionName=section_name),
+            ],
+            rules=[
+                HTTPRouteRule(
+                    matches=[HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value=prefix))],  # Already charm HTTPRouteMatch models
+                    backendRefs=[],  # No backends for redirect routes
+                    filters=filters,
+                )
+            ],
+        ),
     )
 
 
 def normalize_ipa_routes(
-    application_route_data: dict, is_tls_enabled: bool, ingress_app_name: str
-) -> List[HTTPRoute]:
+    application_route_data: dict, is_tls_enabled: bool, ingress_app_name: str, ingress_model_name: str
+) -> List[HTTPRouteResource]:
     """Normalize IPA routes to common format with complete conversion to charm models.
 
     Converts IPA raw route data to fully normalized K8s Gateway API format using charm Pydantic models.
@@ -263,11 +248,12 @@ def normalize_ipa_routes(
         application_route_data: Dict mapping (app_name, relation_name) to route data
         is_tls_enabled: Whether TLS is enabled
         ingress_app_name: Name of the ingress charm app (used in route naming)
+        ingress_model_name: Name of the ingress charm's model
 
     Returns:
         List of normalized HTTP routes with charm models (HTTPRouteMatch, BackendRef, HTTPRouteFilter)
     """
-    routes: List[HTTPRoute] = []
+    routes: List[HTTPRouteResource] = []
 
     for (app_name, relation_name), route_data in application_route_data.items():
         for route in route_data["routes"]:
@@ -309,6 +295,7 @@ def normalize_ipa_routes(
                         source_app=app_name,
                         source_relation=relation_name,
                         ingress_app_name=ingress_app_name,
+                        ingress_model_name=ingress_model_name
                     )
                 )
 
@@ -316,55 +303,59 @@ def normalize_ipa_routes(
                 section_name = "https-443"
                 route_name = f"{route['service_name']}-httproute-{section_name}-{ingress_app_name}"
                 routes.append(
-                    HTTPRoute(
-                        resource = HTTPRouteResource(
-                            metadata=Metadata(
-                                name=route_name,
-                                namespace=route["namespace"],
-                            ),
-                            spec=HTTPRouteResourceSpec(
-                                parentRefs=[],
-                                rules=[
-                                    HTTPRouteRule(
-                                        matches=matches,  # Already charm HTTPRouteMatch models
-                                        backendRefs=backend_refs,  # Already charm BackendRef models
-                                        filters=filters if filters else None,
-                                    )
-                                ],
-                            ),
+                    HTTPRouteResource(
+                        metadata=Metadata(
+                            name=route_name,
+                            namespace=route["namespace"],
+                            labels={
+                                ROUTE_LISTENER_PORT_LABEL: "443",
+                                ROUTE_LISTENER_PROTOCOL_LABEL: "HTTPS",
+                                ROUTE_SOURCE_APP_LABEL: app_name,
+                                ROUTE_SOURCE_RELATION_LABEL: relation_name,
+                            }
                         ),
-                        listener_port=443,
-                        listener_protocol="HTTPS",
-                        source_app=app_name,
-                        source_relation=relation_name,
-                    )
+                        spec=HTTPRouteResourceSpec(
+                            parentRefs=[
+                                ParentRef(name=ingress_app_name,namespace=ingress_model_name,sectionName=section_name)
+                            ],
+                            rules=[
+                                HTTPRouteRule(
+                                    matches=matches,  # Already charm HTTPRouteMatch models
+                                    backendRefs=backend_refs,  # Already charm BackendRef models
+                                    filters=filters if filters else None,
+                                )
+                            ],
+                        ),
+                    ),
                 )
             else:
                 # Create HTTP route
                 section_name = "http-80"
                 route_name = f"{route['service_name']}-httproute-{section_name}-{ingress_app_name}"
                 routes.append(
-                    HTTPRoute(
-                        resource = HTTPRouteResource(
-                            metadata=Metadata(
-                                name=route_name,
-                                namespace=route["namespace"],
-                            ),
-                            spec=HTTPRouteResourceSpec(
-                                parentRefs=[],
-                                rules=[
-                                    HTTPRouteRule(
-                                        matches=matches,  # Already charm HTTPRouteMatch models
-                                        backendRefs=backend_refs,  # Already charm BackendRef models
-                                        filters=filters if filters else None,
-                                    )
-                                ],
-                            ),
+                    HTTPRouteResource(
+                        metadata=Metadata(
+                            name=route_name,
+                            namespace=route["namespace"],
+                            labels={
+                                ROUTE_LISTENER_PORT_LABEL: "80",
+                                ROUTE_LISTENER_PROTOCOL_LABEL: "HTTP",
+                                ROUTE_SOURCE_APP_LABEL: app_name,
+                                ROUTE_SOURCE_RELATION_LABEL: relation_name,
+                            }
                         ),
-                        listener_port=80,
-                        listener_protocol="HTTP",
-                        source_app=app_name,
-                        source_relation=relation_name,
+                        spec=HTTPRouteResourceSpec(
+                            parentRefs=[
+                                ParentRef(name=ingress_app_name,namespace=ingress_model_name,sectionName=section_name)
+                            ],
+                            rules=[
+                                HTTPRouteRule(
+                                    matches=matches,  # Already charm HTTPRouteMatch models
+                                    backendRefs=backend_refs,  # Already charm BackendRef models
+                                    filters=filters if filters else None,
+                                )
+                            ],
+                        ),
                     )
                 )
 
@@ -372,8 +363,8 @@ def normalize_ipa_routes(
 
 
 def normalize_istio_ingress_route_http_routes(
-    istio_ingress_route_configs: dict, is_tls_enabled: bool, ingress_app_name: str
-) -> List[HTTPRoute]:
+    istio_ingress_route_configs: dict, is_tls_enabled: bool, ingress_app_name: str, ingress_model_name: str
+) -> List[HTTPRouteResource]:
     """Normalize istio-ingress-route HTTP routes to common format with complete conversion to charm models.
 
     Converts library models (from istio_ingress_route relation) to charm Pydantic models.
@@ -383,11 +374,12 @@ def normalize_istio_ingress_route_http_routes(
         istio_ingress_route_configs: Dict mapping (app_name, relation_name) to config data
         is_tls_enabled: Whether TLS is enabled
         ingress_app_name: Name of the ingress charm app (used in route naming)
+        ingress_model_name: Name of the ingress charm's model
 
     Returns:
         List of normalized HTTP routes with charm models (HTTPRouteMatch, BackendRef, HTTPRouteFilter)
     """
-    routes: List[HTTPRoute] = []
+    routes: List[HTTPRouteResource] = []
 
     for (app_name, relation_name), config_data in istio_ingress_route_configs.items():
         config = config_data["config"]
@@ -434,27 +426,29 @@ def normalize_istio_ingress_route_http_routes(
             route_name = f"{app_name}-{http_route.name}-httproute-{section_name}-{ingress_app_name}"
 
             routes.append(
-                HTTPRoute(
-                    resource = HTTPRouteResource(
-                        metadata=Metadata(
-                            name=route_name,
-                            namespace=config.model,
-                        ),
-                        spec=HTTPRouteResourceSpec(
-                            parentRefs=[],
-                            rules=[
-                                HTTPRouteRule(
-                                    matches=matches,  # Already charm HTTPRouteMatch models
-                                    backendRefs=backend_refs,  # Already charm BackendRef models
-                                    filters=filters if filters else None,
-                                )
-                            ],
-                        ),
+                HTTPRouteResource(
+                    metadata=Metadata(
+                        name=route_name,
+                        namespace=config.model,
+                        labels={
+                            ROUTE_LISTENER_PORT_LABEL: str(http_route.listener.port),
+                            ROUTE_LISTENER_PROTOCOL_LABEL: gateway_protocol,
+                            ROUTE_SOURCE_APP_LABEL: app_name,
+                            ROUTE_SOURCE_RELATION_LABEL: relation_name,
+                        }
                     ),
-                    listener_port=http_route.listener.port,
-                    listener_protocol=gateway_protocol,
-                    source_app=app_name,
-                    source_relation=relation_name,
+                    spec=HTTPRouteResourceSpec(
+                        parentRefs=[
+                            ParentRef(name=ingress_app_name,namespace=ingress_model_name,sectionName=section_name)
+                        ],
+                        rules=[
+                            HTTPRouteRule(
+                                matches=matches,  # Already charm HTTPRouteMatch models
+                                backendRefs=backend_refs,  # Already charm BackendRef models
+                                filters=filters if filters else None,
+                            )
+                        ],
+                    ),
                 )
             )
 
@@ -462,8 +456,8 @@ def normalize_istio_ingress_route_http_routes(
 
 
 def normalize_istio_ingress_route_grpc_routes(
-    istio_ingress_route_configs: dict, is_tls_enabled: bool, ingress_app_name: str
-) -> List[GRPCRoute]:
+    istio_ingress_route_configs: dict, is_tls_enabled: bool, ingress_app_name: str, ingress_model_name: str
+) -> List[GRPCRouteResource]:
     """Normalize istio-ingress-route gRPC routes to common format with complete conversion to charm models.
 
     Converts library models (from istio_ingress_route relation) to charm Pydantic models (from models.py).
@@ -473,11 +467,12 @@ def normalize_istio_ingress_route_grpc_routes(
         istio_ingress_route_configs: Dict mapping (app_name, relation_name) to config data
         is_tls_enabled: Whether TLS is enabled
         ingress_app_name: Name of the ingress charm app (used in route naming)
+        ingress_model_name: Name of the ingress charm's model
 
     Returns:
         List of normalized gRPC routes with charm models (GRPCRouteMatch, BackendRef, HTTPRouteFilter)
     """
-    routes: List[GRPCRoute] = []
+    routes: List[GRPCRouteResource] = []
 
     for (app_name, relation_name), config_data in istio_ingress_route_configs.items():
         config = config_data["config"]
@@ -526,27 +521,29 @@ def normalize_istio_ingress_route_grpc_routes(
             route_name = f"{app_name}-{grpc_route.name}-grpcroute-{section_name}-{ingress_app_name}"
 
             routes.append(
-                GRPCRoute(
-                    resource=GRPCRouteResource(
-                        metadata=Metadata(
-                            name=route_name,
-                            namespace=config.model,
-                        ),
-                        spec=GRPCRouteResourceSpec(
-                            parentRefs=[],
-                            rules=[
-                                GRPCRouteRule(
-                                    matches=matches,  # Already charm GRPCRouteMatch models
-                                    backendRefs=backend_refs,  # Already charm BackendRef models
-                                    filters=filters if filters else None,
-                                )
-                            ],
-                        ),
+                GRPCRouteResource(
+                    metadata=Metadata(
+                        name=route_name,
+                        namespace=config.model,
+                        labels={
+                            ROUTE_LISTENER_PORT_LABEL: str(grpc_route.listener.port),
+                            ROUTE_LISTENER_PROTOCOL_LABEL: gateway_protocol,
+                            ROUTE_SOURCE_APP_LABEL: app_name,
+                            ROUTE_SOURCE_RELATION_LABEL: relation_name,
+                        }
                     ),
-                    listener_port=grpc_route.listener.port,
-                    listener_protocol=gateway_protocol,
-                    source_app=app_name,
-                    source_relation=relation_name,
+                    spec=GRPCRouteResourceSpec(
+                        parentRefs=[
+                            ParentRef(name=ingress_app_name,namespace=ingress_model_name,sectionName=section_name)
+                        ],
+                        rules=[
+                            GRPCRouteRule(
+                                matches=matches,  # Already charm GRPCRouteMatch models
+                                backendRefs=backend_refs,  # Already charm BackendRef models
+                                filters=filters if filters else None,
+                            )
+                        ],
+                    ),
                 )
             )
 
@@ -594,8 +591,8 @@ def deduplicate_listeners(all_listeners: List[Listener]) -> List[Listener]:
 
 
 def deduplicate_http_routes(
-    all_http_routes: List[HTTPRoute],
-) -> Tuple[List[HTTPRoute], Set[Tuple[str, str]]]:
+    all_http_routes: List[HTTPRouteResource],
+) -> Tuple[List[HTTPRouteResource], Set[Tuple[str, str]]]:
     """Deduplicate HTTP routes by finding conflicts on (listener_port, listener_protocol, path).
 
     Routes from the same app can share the same path. Routes from different apps cannot.
@@ -656,20 +653,23 @@ def deduplicate_http_routes(
     """
     # Group routes by (listener_port, listener_protocol, path)
     # Extract path from first match in matches list
-    route_groups: Dict[Tuple[int, str, str], List[HTTPRoute]] = defaultdict(list)
+    route_groups: Dict[Tuple[int, str, str], List[HTTPRouteResource]] = defaultdict(list)
 
     for route in all_http_routes:
         # Extract path from first HTTPRouteMatch
-        path = _get_first_rules_first_http_path(route)
-        key = (route.listener_port, route.listener_protocol, path)
+        key = (
+              get_listener_port_from_label(route.metadata),
+              get_listener_protocol_from_label(route.metadata),
+              _get_first_rules_first_http_path(route),
+        )
         route_groups[key].append(route)
 
-    valid_routes: List[HTTPRoute] = []
+    valid_routes: List[HTTPRouteResource] = []
     apps_to_clear: Set[Tuple[str, str]] = set()
 
     for key, routes in route_groups.items():
         # Get unique apps requesting this route
-        unique_apps = {(r.source_app, r.source_relation) for r in routes}
+        unique_apps = {get_requesting_app_and_relation_forom_label(r.metadata) for r in routes}
 
         if len(unique_apps) > 1:
             # Conflict detected - multiple apps want the same route
@@ -690,8 +690,8 @@ def deduplicate_http_routes(
 
 
 def deduplicate_grpc_routes(
-    all_grpc_routes: List[GRPCRoute],
-) -> Tuple[List[GRPCRoute], Set[Tuple[str, str]]]:
+    all_grpc_routes: List[GRPCRouteResource],
+) -> Tuple[List[GRPCRouteResource], Set[Tuple[str, str]]]:
     """Deduplicate gRPC routes by finding conflicts on (listener_port, listener_protocol, grpc_path).
 
     Routes from the same app can share the same gRPC path. Routes from different apps cannot.
@@ -750,19 +750,22 @@ def deduplicate_grpc_routes(
     """
     # Group routes by (listener_port, listener_protocol, grpc_path)
     # Extract grpc_path from first match in matches list
-    route_groups: Dict[Tuple[int, str, str], List[GRPCRoute]] = defaultdict(list)
+    route_groups: Dict[Tuple[int, str, str], List[GRPCRouteResource]] = defaultdict(list)
 
     for route in all_grpc_routes:
-        grpc_path = _get_first_rules_first_grpc_path(route)
-        key = (route.listener_port, route.listener_protocol, grpc_path)
+        key = (
+            get_listener_port_from_label(route.metadata),
+            get_listener_protocol_from_label(route.metadata),
+            _get_first_rules_first_grpc_path(route)
+        )
         route_groups[key].append(route)
 
-    valid_routes: List[GRPCRoute] = []
+    valid_routes: List[GRPCRouteResource] = []
     apps_to_clear: Set[Tuple[str, str]] = set()
 
     for key, routes in route_groups.items():
         # Get unique apps requesting this route
-        unique_apps = {(r.source_app, r.source_relation) for r in routes}
+        unique_apps = {get_requesting_app_and_relation_forom_label(r.metadata) for r in routes}
 
         if len(unique_apps) > 1:
             # Conflict detected - multiple apps want the same route
@@ -943,13 +946,13 @@ def create_gateway_tls_config(tls_secret_name: str) -> GatewayTLSConfig:
     """Return a simple GatewayTLSConfig object based on the provided tls_secret_name."""
     return GatewayTLSConfig(certificateRefs=[SecretObjectReference(name=tls_secret_name)])
 
-def _get_first_rules_first_http_path(route: HTTPRoute) -> str:
-    matches = route.resource.spec.rules[0].matches
+def _get_first_rules_first_http_path(route: HTTPRouteResource) -> str:
+    matches = route.spec.rules[0].matches
     return matches[0].path.value if matches else "/"
 
 
-def _get_first_rules_first_grpc_path(route: GRPCRoute) -> str:
-    matches = route.resource.spec.rules[0].matches
+def _get_first_rules_first_grpc_path(route: GRPCRouteResource) -> str:
+    matches = route.spec.rules[0].matches
     if matches and matches[0].method:
         method_match = matches[0].method
         service = method_match.service or ""
@@ -957,3 +960,20 @@ def _get_first_rules_first_grpc_path(route: GRPCRoute) -> str:
         return f"/{service}/{method}"
     else:
         return "/*"
+
+def get_listener_port_from_label(metadata: Metadata) -> int:
+    """Extract the listener port from the metadata of a GRPCRouteResource or HTTPRouteResource using its labels."""
+    assert metadata.labels is not None
+    return int(metadata.labels[ROUTE_LISTENER_PORT_LABEL])
+
+def get_listener_protocol_from_label(metadata: Metadata) -> str:
+    """Extract the listener protocol from the metadata of a GRPCRouteResource or HTTPRouteResource using its labels."""
+    assert metadata.labels is not None
+    return str(metadata.labels[ROUTE_LISTENER_PROTOCOL_LABEL])
+
+def get_requesting_app_and_relation_forom_label(metadata: Metadata) -> Tuple[str,str]:
+    """Extract the name of the requesting app and relation from the metadata of a GRPCRouteResource or HTTPRouteResource using its labels."""
+    assert metadata.labels is not None
+    source_app = str(metadata.labels[ROUTE_SOURCE_APP_LABEL])
+    source_relation = str(metadata.labels[ROUTE_SOURCE_RELATION_LABEL])
+    return (source_app,source_relation)

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,13 +15,13 @@ from typing import Dict, List, Optional, Set, Tuple, TypedDict
 from canonical_service_mesh.models import (
     AllowedRoutes,
     BackendRef,
-    GatewayTLSConfig,  
+    GatewayTLSConfig,
     GRPCMethodMatch,
     GRPCRouteMatch,
     HTTPPathMatch,
     HTTPRouteMatch,
     Listener,
-    SecretObjectReference
+    SecretObjectReference,
 )
 from charmlibs.interfaces.istio_ingress_route import (
     PathModifier,
@@ -180,7 +180,7 @@ def normalize_istio_ingress_route_listeners(
 
             tls_config = None
             if tls_secret_name is not None:
-                tls_config = create_gateway_tls_config(tls_secret_name) 
+                tls_config = create_gateway_tls_config(tls_secret_name)
 
             listeners.append(
                 Listener(

--- a/src/utils.py
+++ b/src/utils.py
@@ -13,11 +13,15 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, TypedDict
 
 from canonical_service_mesh.models import (
+    AllowedRoutes,
     BackendRef,
+    GatewayTLSConfig,  
     GRPCMethodMatch,
     GRPCRouteMatch,
     HTTPPathMatch,
     HTTPRouteMatch,
+    Listener,
+    SecretObjectReference
 )
 from charmlibs.interfaces.istio_ingress_route import (
     PathModifier,
@@ -77,15 +81,6 @@ class RouteInfo(TypedDict):
     prefix: Optional[str]
 
 
-class GatewayListener(TypedDict):
-    """Normalized Gateway listener data structure."""
-
-    port: int
-    gateway_protocol: str
-    tls_secret_name: Optional[str]
-    source_app: str
-
-
 class HTTPRoute(TypedDict):
     """Normalized HTTPRoute data structure.
 
@@ -123,7 +118,7 @@ class GRPCRoute(TypedDict):
 # ============================================================================
 # Adapters
 # ============================================================================
-def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[GatewayListener]:
+def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[Listener]:
     """Normalize IPA listeners to common format.
 
     IPA always uses standard ports: 80 for HTTP, 443 for HTTPS.
@@ -134,22 +129,24 @@ def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[GatewayListe
     Returns:
         List of normalized listeners (http-80, and https-443 if TLS enabled)
     """
-    listeners: List[GatewayListener] = [
-        GatewayListener(
+    listeners: List[Listener] = [
+        Listener(
+            name="",
             port=80,
-            gateway_protocol="HTTP",
-            tls_secret_name=None,
-            source_app="ipa",
+            protocol="HTTP",
+            allowedRoutes=AllowedRoutes(namespaces={}),
+            tls=None,
         )
     ]
 
     if tls_secret_name:
         listeners.append(
-            GatewayListener(
+            Listener(
+                name="",
                 port=443,
-                gateway_protocol="HTTPS",
-                tls_secret_name=tls_secret_name,
-                source_app="ipa",
+                protocol="HTTPS",
+                allowedRoutes=AllowedRoutes(namespaces={}),
+                tls=create_gateway_tls_config(tls_secret_name) # tls_secret_name,
             )
         )
 
@@ -158,7 +155,7 @@ def normalize_ipa_listeners(tls_secret_name: Optional[str]) -> List[GatewayListe
 
 def normalize_istio_ingress_route_listeners(
     istio_ingress_route_configs: dict, tls_secret_name: Optional[str]
-) -> List[GatewayListener]:
+) -> List[Listener]:
     """Normalize istio-ingress-route listeners to common format.
 
     Args:
@@ -168,9 +165,9 @@ def normalize_istio_ingress_route_listeners(
     Returns:
         List of normalized listeners
     """
-    listeners: List[GatewayListener] = []
+    listeners: List[Listener] = []
 
-    for (app_name, relation_name), config_data in istio_ingress_route_configs.items():
+    for (app_name, _), config_data in istio_ingress_route_configs.items():
         config = config_data["config"]
         if not config:
             continue
@@ -181,12 +178,18 @@ def normalize_istio_ingress_route_listeners(
                 listener.protocol, tls_enabled=tls_secret_name is not None
             )
 
+            tls_config = None
+            if tls_secret_name is not None:
+                tls_config = create_gateway_tls_config(tls_secret_name) 
+
             listeners.append(
-                GatewayListener(
+                Listener(
+                    name="",
                     port=listener.port,
-                    gateway_protocol=gateway_protocol,
-                    tls_secret_name=tls_secret_name if gateway_protocol == "HTTPS" else None,
-                    source_app=app_name,
+                    protocol=gateway_protocol,
+                    allowedRoutes=AllowedRoutes(namespaces={}),
+                    tls=tls_config,
+                    # source_app=app_name,
                 )
             )
 
@@ -502,7 +505,7 @@ def normalize_istio_ingress_route_grpc_routes(
 # ============================================================================
 # Generic Processing Functions (work on normalized data)
 # ============================================================================
-def deduplicate_listeners(all_listeners: List[GatewayListener]) -> List[GatewayListener]:
+def deduplicate_listeners(all_listeners: List[Listener]) -> List[Listener]:
     """Merge listeners by deduplicating on (port, gateway_protocol).
 
     Keeps the first occurrence of each unique (port, protocol) combination.
@@ -510,17 +513,17 @@ def deduplicate_listeners(all_listeners: List[GatewayListener]) -> List[GatewayL
 
     For example, given input:
         [
-            _GatewayListener(port=80, gateway_protocol="HTTP", source_app="ipa", ...),
-            _GatewayListener(port=443, gateway_protocol="HTTPS", source_app="ipa", ...),
-            _GatewayListener(port=80, gateway_protocol="HTTP", source_app="app1", ...),  # Duplicate
-            _GatewayListener(port=8080, gateway_protocol="HTTP", source_app="app2", ...),
+            Listener(port=80, protocol="HTTP", name="x", ...),
+            Listener(port=443, protocol="HTTPS", ...),
+            Listener(port=80, protocol="HTTP", name="y" ...),  # Duplicate
+            Listener(port=8080, protocol="HTTP", ...),
         ]
 
     This function would return:
         [
-            _GatewayListener(port=80, gateway_protocol="HTTP", source_app="ipa", ...),    # First wins
-            _GatewayListener(port=443, gateway_protocol="HTTPS", source_app="ipa", ...),
-            _GatewayListener(port=8080, gateway_protocol="HTTP", source_app="app2", ...),
+            Listener(port=80, protocol="HTTP", name="x", ...),    # First wins
+            Listener(port=443, protocol="HTTPS", ...),
+            Listener(port=8080, protocol="HTTP", ...),
         ]
 
     Args:
@@ -529,10 +532,10 @@ def deduplicate_listeners(all_listeners: List[GatewayListener]) -> List[GatewayL
     Returns:
         List of unique listeners (first occurrence wins for each unique port/protocol pair)
     """
-    seen: Dict[Tuple[int, str], GatewayListener] = {}
+    seen: Dict[Tuple[int, str], Listener] = {}
 
     for listener in all_listeners:
-        key = (listener["port"], listener["gateway_protocol"])
+        key = (listener.port, listener.protocol)
         if key not in seen:
             seen[key] = listener
 
@@ -894,3 +897,6 @@ def get_relation_by_name_and_app(relations, remote_app_name):
     raise KeyError(f"Could not find relation with remote_app_name={remote_app_name}")
 
 
+def create_gateway_tls_config(tls_secret_name: str) -> GatewayTLSConfig:
+    """Return a simple GatewayTLSConfig object based on the provided tls_secret_name."""
+    return GatewayTLSConfig(certificateRefs=[SecretObjectReference(name=tls_secret_name)])

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,7 +20,11 @@ from canonical_service_mesh.models import (
     GRPCRouteMatch,
     HTTPPathMatch,
     HTTPRouteMatch,
+    HTTPRouteResource,
+    HTTPRouteResourceSpec,
+    HTTPRouteRule,
     Listener,
+    Metadata,
     SecretObjectReference,
 )
 from charmlibs.interfaces.istio_ingress_route import (
@@ -33,6 +37,7 @@ from charmlibs.interfaces.istio_ingress_route import (
     to_gateway_protocol,
 )
 from ops import EventBase
+from pydantic import BaseModel
 
 HTTPRouteFilter = URLRewriteFilter | RequestRedirectFilter
 GRPCRouteFilter = RequestRedirectFilter
@@ -80,22 +85,41 @@ class RouteInfo(TypedDict):
     strip_prefix: bool
     prefix: Optional[str]
 
+# TODO: replace with HTTPRouteResource
+#class HTTPRoute(TypedDict):
+#    pass
 
-class HTTPRoute(TypedDict):
+
+class HTTPRoute(BaseModel):
     """Normalized HTTPRoute data structure.
 
     All fields use charm models from models.py (K8s Gateway API format).
     """
-
-    name: str
-    listener_port: int
-    listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
-    namespace: str
+    resource: HTTPRouteResource
     source_app: str
     source_relation: str
-    matches: List[HTTPRouteMatch]
-    backend_refs: List[BackendRef]
-    filters: List[HTTPRouteFilter]
+    listener_port: int
+    listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
+
+#    # metadata.name
+#    name: str
+#    # as listener
+#    listener_port: int
+#    listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
+#
+#    # metadata.namespace
+#    namespace: str
+#
+#    # ???
+#
+#    # spec.rules[].matches
+#    matches: List[HTTPRouteMatch]
+#
+#    # spec.rules[].backendRefs
+#    backend_refs: List[BackendRef]
+#
+#    # spec.rules[].filters
+#    filters: List[HTTPRouteFilter]
 
 
 class GRPCRoute(TypedDict):
@@ -228,19 +252,26 @@ def _create_http_redirect_route(
     )
 
     return HTTPRoute(
-        name=route_name,
+        resource=HTTPRouteResource(
+                metadata=Metadata(
+                    name=route_name,
+                    namespace=namespace,
+                ),
+                spec=HTTPRouteResourceSpec(
+                    parentRefs=[], # Maybe encode remaining fields here
+                    rules=[
+                        HTTPRouteRule(
+                            matches=[HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value=prefix))],  # Already charm HTTPRouteMatch models
+                            backendRefs=[],  # No backends for redirect routes
+                            filters=filters,
+                        )
+                    ],
+                ),
+            ),
         listener_port=80,
         listener_protocol="HTTP",
-        namespace=namespace,
         source_app=source_app,
         source_relation=source_relation,
-        matches=[
-            HTTPRouteMatch(
-                path=HTTPPathMatch(type="PathPrefix", value=prefix)
-            )
-        ],
-        backend_refs=[],  # No backends for redirect routes
-        filters=filters,
     )
 
 
@@ -310,15 +341,26 @@ def normalize_ipa_routes(
                 route_name = f"{route['service_name']}-httproute-{section_name}-{ingress_app_name}"
                 routes.append(
                     HTTPRoute(
-                        name=route_name,
+                        resource = HTTPRouteResource(
+                            metadata=Metadata(
+                                name=route_name,
+                                namespace=route["namespace"],
+                            ),
+                            spec=HTTPRouteResourceSpec(
+                                parentRefs=[],
+                                rules=[
+                                    HTTPRouteRule(
+                                        matches=matches,  # Already charm HTTPRouteMatch models
+                                        backendRefs=backend_refs,  # Already charm BackendRef models
+                                        filters=filters if filters else None,
+                                    )
+                                ],
+                            ),
+                        ),
                         listener_port=443,
                         listener_protocol="HTTPS",
-                        namespace=route["namespace"],
                         source_app=app_name,
                         source_relation=relation_name,
-                        matches=matches,
-                        backend_refs=backend_refs,
-                        filters=filters,
                     )
                 )
             else:
@@ -327,15 +369,26 @@ def normalize_ipa_routes(
                 route_name = f"{route['service_name']}-httproute-{section_name}-{ingress_app_name}"
                 routes.append(
                     HTTPRoute(
-                        name=route_name,
+                        resource = HTTPRouteResource(
+                            metadata=Metadata(
+                                name=route_name,
+                                namespace=route["namespace"],
+                            ),
+                            spec=HTTPRouteResourceSpec(
+                                parentRefs=[],
+                                rules=[
+                                    HTTPRouteRule(
+                                        matches=matches,  # Already charm HTTPRouteMatch models
+                                        backendRefs=backend_refs,  # Already charm BackendRef models
+                                        filters=filters if filters else None,
+                                    )
+                                ],
+                            ),
+                        ),
                         listener_port=80,
                         listener_protocol="HTTP",
-                        namespace=route["namespace"],
                         source_app=app_name,
                         source_relation=relation_name,
-                        matches=matches,
-                        backend_refs=backend_refs,
-                        filters=filters,
                     )
                 )
 
@@ -347,7 +400,7 @@ def normalize_istio_ingress_route_http_routes(
 ) -> List[HTTPRoute]:
     """Normalize istio-ingress-route HTTP routes to common format with complete conversion to charm models.
 
-    Converts library models (from istio_ingress_route relation) to charm Pydantic models (from models.py).
+    Converts library models (from istio_ingress_route relation) to charm Pydantic models.
     This ensures complete normalization to K8s Gateway API format.
 
     Args:
@@ -406,15 +459,26 @@ def normalize_istio_ingress_route_http_routes(
 
             routes.append(
                 HTTPRoute(
-                    name=route_name,
+                    resource = HTTPRouteResource(
+                        metadata=Metadata(
+                            name=route_name,
+                            namespace=config.model,
+                        ),
+                        spec=HTTPRouteResourceSpec(
+                            parentRefs=[],
+                            rules=[
+                                HTTPRouteRule(
+                                    matches=matches,  # Already charm HTTPRouteMatch models
+                                    backendRefs=backend_refs,  # Already charm BackendRef models
+                                    filters=filters if filters else None,
+                                )
+                            ],
+                        ),
+                    ),
                     listener_port=http_route.listener.port,
                     listener_protocol=gateway_protocol,
-                    namespace=config.model,
                     source_app=app_name,
                     source_relation=relation_name,
-                    matches=matches,
-                    backend_refs=backend_refs,
-                    filters=filters,
                 )
             )
 
@@ -542,6 +606,11 @@ def deduplicate_listeners(all_listeners: List[Listener]) -> List[Listener]:
     return list(seen.values())
 
 
+def _get_first_rules_first_path(route: HTTPRoute) -> str:
+    matches = route.resource.spec.rules[0].matches
+    return matches[0].path.value if matches else "/"
+
+
 def deduplicate_http_routes(
     all_http_routes: List[HTTPRoute],
 ) -> Tuple[List[HTTPRoute], Set[Tuple[str, str]]]:
@@ -602,7 +671,6 @@ def deduplicate_http_routes(
         Tuple of (valid_routes, apps_to_clear, has_conflicts) where:
         - valid_routes: List of non-conflicting routes
         - apps_to_clear: Set of (app_name, relation_name) tuples that have conflicts
-        - has_conflicts: True if any conflicts were detected (caller should set BlockedStatus)
     """
     # Group routes by (listener_port, listener_protocol, path)
     # Extract path from first match in matches list
@@ -610,8 +678,8 @@ def deduplicate_http_routes(
 
     for route in all_http_routes:
         # Extract path from first HTTPRouteMatch
-        path = route["matches"][0].path.value if route["matches"] else "/"
-        key = (route["listener_port"], route["listener_protocol"], path)
+        path = _get_first_rules_first_path(route)
+        key = (route.listener_port, route.listener_protocol, path)
         route_groups[key].append(route)
 
     valid_routes: List[HTTPRoute] = []
@@ -619,7 +687,7 @@ def deduplicate_http_routes(
 
     for key, routes in route_groups.items():
         # Get unique apps requesting this route
-        unique_apps = {(r["source_app"], r["source_relation"]) for r in routes}
+        unique_apps = {(r.source_app, r.source_relation) for r in routes}
 
         if len(unique_apps) > 1:
             # Conflict detected - multiple apps want the same route

--- a/src/utils.py
+++ b/src/utils.py
@@ -18,6 +18,9 @@ from canonical_service_mesh.models import (
     GatewayTLSConfig,
     GRPCMethodMatch,
     GRPCRouteMatch,
+    GRPCRouteResource,
+    GRPCRouteResourceSpec,
+    GRPCRouteRule,
     HTTPPathMatch,
     HTTPRouteMatch,
     HTTPRouteResource,
@@ -85,58 +88,31 @@ class RouteInfo(TypedDict):
     strip_prefix: bool
     prefix: Optional[str]
 
-# TODO: replace with HTTPRouteResource
-#class HTTPRoute(TypedDict):
-#    pass
-
 
 class HTTPRoute(BaseModel):
     """Normalized HTTPRoute data structure.
 
     All fields use charm models from models.py (K8s Gateway API format).
     """
+
     resource: HTTPRouteResource
     source_app: str
     source_relation: str
     listener_port: int
     listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
 
-#    # metadata.name
-#    name: str
-#    # as listener
-#    listener_port: int
-#    listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
-#
-#    # metadata.namespace
-#    namespace: str
-#
-#    # ???
-#
-#    # spec.rules[].matches
-#    matches: List[HTTPRouteMatch]
-#
-#    # spec.rules[].backendRefs
-#    backend_refs: List[BackendRef]
-#
-#    # spec.rules[].filters
-#    filters: List[HTTPRouteFilter]
 
-
-class GRPCRoute(TypedDict):
+class GRPCRoute(BaseModel):
     """Normalized GRPCRoute data structure.
 
     All fields use charm models from models.py (K8s Gateway API format).
     """
 
-    name: str
+    resource: GRPCRouteResource
     listener_port: int
     listener_protocol: str  # Gateway protocol ("HTTP" or "HTTPS")
-    namespace: str
     source_app: str
     source_relation: str
-    matches: List[GRPCRouteMatch]
-    backend_refs: List[BackendRef]
-    filters: List[GRPCRouteFilter]
 
 
 # ============================================================================
@@ -539,7 +515,7 @@ def normalize_istio_ingress_route_grpc_routes(
                 )
 
             # GRPCRouteFilter not yet implemented - leave empty for now
-            filters = []
+            filters: List[GRPCRouteFilter] = []
             # TODO: When GRPCRouteFilter is implemented, use:
             # filters = list(grpc_route.filters) if grpc_route.filters else []
 
@@ -551,15 +527,26 @@ def normalize_istio_ingress_route_grpc_routes(
 
             routes.append(
                 GRPCRoute(
-                    name=route_name,
+                    resource=GRPCRouteResource(
+                        metadata=Metadata(
+                            name=route_name,
+                            namespace=config.model,
+                        ),
+                        spec=GRPCRouteResourceSpec(
+                            parentRefs=[],
+                            rules=[
+                                GRPCRouteRule(
+                                    matches=matches,  # Already charm GRPCRouteMatch models
+                                    backendRefs=backend_refs,  # Already charm BackendRef models
+                                    filters=filters if filters else None,
+                                )
+                            ],
+                        ),
+                    ),
                     listener_port=grpc_route.listener.port,
                     listener_protocol=gateway_protocol,
-                    namespace=config.model,
                     source_app=app_name,
                     source_relation=relation_name,
-                    matches=matches,
-                    backend_refs=backend_refs,
-                    filters=filters,
                 )
             )
 
@@ -604,11 +591,6 @@ def deduplicate_listeners(all_listeners: List[Listener]) -> List[Listener]:
             seen[key] = listener
 
     return list(seen.values())
-
-
-def _get_first_rules_first_path(route: HTTPRoute) -> str:
-    matches = route.resource.spec.rules[0].matches
-    return matches[0].path.value if matches else "/"
 
 
 def deduplicate_http_routes(
@@ -678,7 +660,7 @@ def deduplicate_http_routes(
 
     for route in all_http_routes:
         # Extract path from first HTTPRouteMatch
-        path = _get_first_rules_first_path(route)
+        path = _get_first_rules_first_http_path(route)
         key = (route.listener_port, route.listener_protocol, path)
         route_groups[key].append(route)
 
@@ -771,16 +753,8 @@ def deduplicate_grpc_routes(
     route_groups: Dict[Tuple[int, str, str], List[GRPCRoute]] = defaultdict(list)
 
     for route in all_grpc_routes:
-        # Extract gRPC path from first GRPCRouteMatch
-        if route["matches"] and route["matches"][0].method:
-            method_match = route["matches"][0].method
-            service = method_match.service or ""
-            method = method_match.method or "*"
-            grpc_path = f"/{service}/{method}"
-        else:
-            grpc_path = "/*"
-
-        key = (route["listener_port"], route["listener_protocol"], grpc_path)
+        grpc_path = _get_first_rules_first_grpc_path(route)
+        key = (route.listener_port, route.listener_protocol, grpc_path)
         route_groups[key].append(route)
 
     valid_routes: List[GRPCRoute] = []
@@ -788,7 +762,7 @@ def deduplicate_grpc_routes(
 
     for key, routes in route_groups.items():
         # Get unique apps requesting this route
-        unique_apps = {(r["source_app"], r["source_relation"]) for r in routes}
+        unique_apps = {(r.source_app, r.source_relation) for r in routes}
 
         if len(unique_apps) > 1:
             # Conflict detected - multiple apps want the same route
@@ -968,3 +942,18 @@ def get_relation_by_name_and_app(relations, remote_app_name):
 def create_gateway_tls_config(tls_secret_name: str) -> GatewayTLSConfig:
     """Return a simple GatewayTLSConfig object based on the provided tls_secret_name."""
     return GatewayTLSConfig(certificateRefs=[SecretObjectReference(name=tls_secret_name)])
+
+def _get_first_rules_first_http_path(route: HTTPRoute) -> str:
+    matches = route.resource.spec.rules[0].matches
+    return matches[0].path.value if matches else "/"
+
+
+def _get_first_rules_first_grpc_path(route: GRPCRoute) -> str:
+    matches = route.resource.spec.rules[0].matches
+    if matches and matches[0].method:
+        method_match = matches[0].method
+        service = method_match.service or ""
+        method = method_match.method or "*"
+        return f"/{service}/{method}"
+    else:
+        return "/*"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,13 +4,16 @@
 # See LICENSE file for licensing details.
 
 from canonical_service_mesh.models import (
+    GRPCRouteResource,
+    GRPCRouteResourceSpec,
+    GRPCRouteRule,
     HTTPRouteResource,
     HTTPRouteResourceSpec,
     HTTPRouteRule,
     Metadata,
 )
 
-from utils import HTTPRoute
+from utils import GRPCRoute, HTTPRoute
 
 
 def dict_to_httproute(d) -> HTTPRoute :
@@ -31,6 +34,31 @@ def dict_to_httproute(d) -> HTTPRoute :
                     ],
                 ),
             ),
+        listener_port=d["listener_port"],
+        listener_protocol=d["listener_protocol"],
+        source_app=d["source_app"],
+        source_relation=d["source_relation"],
+    )
+
+
+def dict_to_grpcroute(d) -> GRPCRoute:
+    return GRPCRoute(
+        resource=GRPCRouteResource(
+            metadata=Metadata(
+                name=d["name"],
+                namespace=d["namespace"],
+            ),
+            spec=GRPCRouteResourceSpec(
+                parentRefs=[],
+                rules=[
+                    GRPCRouteRule(
+                        matches=d["matches"],
+                        backendRefs=d["backend_refs"],
+                        filters=d["filters"] if "filters" in d and d["filters"] else None,
+                    )
+                ],
+            ),
+        ),
         listener_port=d["listener_port"],
         listener_protocol=d["listener_protocol"],
         source_app=d["source_app"],

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from canonical_service_mesh.models import (
+    HTTPRouteResource,
+    HTTPRouteResourceSpec,
+    HTTPRouteRule,
+    Metadata,
+)
+
+from utils import HTTPRoute
+
+
+def dict_to_httproute(d) -> HTTPRoute :
+    return HTTPRoute(
+        resource=HTTPRouteResource(
+                metadata=Metadata(
+                    name=d["name"],
+                    namespace=d["namespace"],
+                ),
+                spec=HTTPRouteResourceSpec(
+                    parentRefs=[],
+                    rules=[
+                        HTTPRouteRule(
+                            matches=d["matches"],
+                            backendRefs=d["backend_refs"],
+                            filters=d["filters"],
+                        )
+                    ],
+                ),
+            ),
+        listener_port=d["listener_port"],
+        listener_protocol=d["listener_protocol"],
+        source_app=d["source_app"],
+        source_relation=d["source_relation"],
+    )

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -13,54 +13,59 @@ from canonical_service_mesh.models import (
     Metadata,
 )
 
-from utils import GRPCRoute, HTTPRoute
+from utils import (
+    ROUTE_LISTENER_PORT_LABEL,
+    ROUTE_LISTENER_PROTOCOL_LABEL,
+    ROUTE_SOURCE_APP_LABEL,
+    ROUTE_SOURCE_RELATION_LABEL,
+)
 
 
-def dict_to_httproute(d) -> HTTPRoute :
-    return HTTPRoute(
-        resource=HTTPRouteResource(
-                metadata=Metadata(
-                    name=d["name"],
-                    namespace=d["namespace"],
-                ),
-                spec=HTTPRouteResourceSpec(
-                    parentRefs=[],
-                    rules=[
-                        HTTPRouteRule(
-                            matches=d["matches"],
-                            backendRefs=d["backend_refs"],
-                            filters=d["filters"],
-                        )
-                    ],
-                ),
-            ),
-        listener_port=d["listener_port"],
-        listener_protocol=d["listener_protocol"],
-        source_app=d["source_app"],
-        source_relation=d["source_relation"],
+def dict_to_httproute(d) -> HTTPRouteResource :
+    return HTTPRouteResource(
+        metadata=Metadata(
+            name=d["name"],
+            namespace=d["namespace"],
+            labels={
+                ROUTE_LISTENER_PORT_LABEL: str(d["listener_port"]),
+                ROUTE_LISTENER_PROTOCOL_LABEL: d["listener_protocol"],
+                ROUTE_SOURCE_APP_LABEL: d["source_app"],
+                ROUTE_SOURCE_RELATION_LABEL: d["source_relation"],
+            }
+        ),
+        spec=HTTPRouteResourceSpec(
+            parentRefs = d["parentRefs"] if "parentRefs" in d else [],
+            rules=[
+                HTTPRouteRule(
+                    matches=d["matches"],
+                    backendRefs=d["backend_refs"],
+                    filters=d["filters"],
+                )
+            ],
+        ),
     )
 
 
-def dict_to_grpcroute(d) -> GRPCRoute:
-    return GRPCRoute(
-        resource=GRPCRouteResource(
-            metadata=Metadata(
-                name=d["name"],
-                namespace=d["namespace"],
-            ),
-            spec=GRPCRouteResourceSpec(
-                parentRefs=[],
-                rules=[
-                    GRPCRouteRule(
-                        matches=d["matches"],
-                        backendRefs=d["backend_refs"],
-                        filters=d["filters"] if "filters" in d and d["filters"] else None,
-                    )
-                ],
-            ),
+def dict_to_grpcroute(d) -> GRPCRouteResource:
+    return GRPCRouteResource(
+        metadata=Metadata(
+            name=d["name"],
+            namespace=d["namespace"],
+            labels={
+                ROUTE_LISTENER_PORT_LABEL: str(d["listener_port"]),
+                ROUTE_LISTENER_PROTOCOL_LABEL: d["listener_protocol"],
+                ROUTE_SOURCE_APP_LABEL: d["source_app"],
+                ROUTE_SOURCE_RELATION_LABEL: d["source_relation"],
+            }
         ),
-        listener_port=d["listener_port"],
-        listener_protocol=d["listener_protocol"],
-        source_app=d["source_app"],
-        source_relation=d["source_relation"],
+        spec=GRPCRouteResourceSpec(
+            parentRefs=[], # TODO
+            rules=[
+                GRPCRouteRule(
+                    matches=d["matches"],
+                    backendRefs=d["backend_refs"],
+                    filters=d["filters"] if "filters" in d and d["filters"] else None,
+                )
+            ],
+        ),
     )

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -26,7 +26,7 @@ from utils import create_gateway_tls_config
 
 
 def create_test_listeners(
-    ports=(80,), protocols=("HTTP",), tls_secret_names=(None,), source_apps=("test-app",)
+    ports=(80,), protocols=("HTTP",), tls_secret_names=(None,), source_apps=("test-app",), hostname=None
 ):
     """Create normalized Listener list for testing."""
     max_len = max(len(ports), len(protocols), len(tls_secret_names), len(source_apps))
@@ -37,10 +37,11 @@ def create_test_listeners(
 
     return [
         Listener(
-            name=source_app,
+            name=f"{protocol.lower()}-{port}",
             port=port,
             protocol=protocol,
             allowedRoutes=AllowedRoutes(namespaces={}),
+            hostname=hostname,
             tls=create_gateway_tls_config(tls_secret_name) if tls_secret_name else None,
         )
         for port, protocol, tls_secret_name, source_app in zip(
@@ -81,8 +82,9 @@ def test_construct_gateway_with_loadbalancer_address(
         state=scenario.State(),
     ) as manager:
         charm = manager.charm
-        normalized_listeners = create_test_listeners()
+        normalized_listeners = create_test_listeners(hostname=charm._get_hostname_from_local_gateway_address())
         gateway = charm._construct_gateway(normalized_listeners)
+        print(gateway)
 
         # Assert that the Gateway has an http listener with the correct configurations
         _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
@@ -109,6 +111,7 @@ def test_construct_gateway_with_tls(
             ports=(80, 443),
             protocols=("HTTP", "HTTPS"),
             tls_secret_names=(None, tls_secret_name),
+            hostname=charm._get_hostname_from_local_gateway_address()
         )
         gateway = charm._construct_gateway(normalized_listeners)
 
@@ -195,6 +198,7 @@ def test_sync_gateway_resources_with_tls_with_loadbalancer_address(
             ports=(80, 443),
             protocols=("HTTP", "HTTPS"),
             tls_secret_names=(None, charm._certificate_secret_name),
+            hostname=charm._get_hostname_from_local_gateway_address()
         )
         charm._sync_gateway_resources(normalized_listeners)
 
@@ -234,6 +238,7 @@ def test_sync_gateway_resources_with_tls_with_external_hostname_config(
             ports=(80, 443),
             protocols=("HTTP", "HTTPS"),
             tls_secret_names=(None, charm._certificate_secret_name),
+            hostname=charm._get_hostname_from_local_gateway_address()
         )
         charm._sync_gateway_resources(normalized_listeners)
 

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -17,14 +17,19 @@ from lightkube.resources.autoscaling_v2 import HorizontalPodAutoscaler
 from lightkube.resources.core_v1 import Secret
 from ops import ActiveStatus
 
+from canonical_service_mesh.models import (
+    AllowedRoutes, 
+    Listener,
+)
+
 from charm import IstioIngressCharm
-from utils import GatewayListener
+from utils import create_gateway_tls_config
 
 
 def create_test_listeners(
     ports=(80,), protocols=("HTTP",), tls_secret_names=(None,), source_apps=("test-app",)
 ):
-    """Create normalized GatewayListener list for testing."""
+    """Create normalized Listener list for testing."""
     max_len = max(len(ports), len(protocols), len(tls_secret_names), len(source_apps))
     ports = ports + (ports[-1],) * (max_len - len(ports)) if ports else (80,) * max_len
     protocols = protocols + (protocols[-1],) * (max_len - len(protocols)) if protocols else ("HTTP",) * max_len
@@ -32,11 +37,12 @@ def create_test_listeners(
     source_apps = source_apps + (source_apps[-1],) * (max_len - len(source_apps)) if source_apps else ("test-app",) * max_len
 
     return [
-        GatewayListener(
+        Listener(
+            name=source_app,
             port=port,
-            gateway_protocol=protocol,
-            tls_secret_name=tls_secret_name,
-            source_app=source_app,
+            protocol=protocol,
+            allowedRoutes=AllowedRoutes(namespaces={}),
+            tls=create_gateway_tls_config(tls_secret_name) if tls_secret_name else None,
         )
         for port, protocol, tls_secret_name, source_app in zip(
             ports, protocols, tls_secret_names, source_apps

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -6,6 +6,10 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import scenario
+from canonical_service_mesh.models import (
+    AllowedRoutes,
+    Listener,
+)
 from charms.tls_certificates_interface.v3.tls_certificates import (
     generate_ca,
     generate_certificate,
@@ -16,11 +20,6 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.autoscaling_v2 import HorizontalPodAutoscaler
 from lightkube.resources.core_v1 import Secret
 from ops import ActiveStatus
-
-from canonical_service_mesh.models import (
-    AllowedRoutes, 
-    Listener,
-)
 
 from charm import IstioIngressCharm
 from utils import create_gateway_tls_config

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -11,6 +11,7 @@ from canonical_service_mesh.models import (
     GRPCRouteMatch,
     HTTPPathMatch,
     HTTPRouteMatch,
+    ParentRef,
 )
 from charmlibs.interfaces.istio_ingress_route import (
     RequestRedirectFilter,
@@ -49,6 +50,7 @@ def create_test_http_routes(routes_info, with_tls=False):
                             requestRedirect=RequestRedirectSpec(scheme="https", statusCode=301)
                         )
                     ],
+                    "parentRefs": [ParentRef(name="fake-ingress_app_name",namespace="fake-ingress_model_name",sectionName='http-80')],
                 })
             )
             # HTTPS route on port 443 with actual backend
@@ -73,6 +75,7 @@ def create_test_http_routes(routes_info, with_tls=False):
                         )
                     ],
                     "filters": [],
+                    "parentRefs": [ParentRef(name="fake-ingress_app_name",namespace="fake-ingress_model_name",sectionName='https-443')],
                 })
             )
         else:
@@ -98,6 +101,7 @@ def create_test_http_routes(routes_info, with_tls=False):
                         )
                     ],
                     "filters": [],
+                    "parentRefs": [ParentRef(name="fake-ingress_app_name",namespace="fake-ingress_model_name",sectionName='http-80')],
                 })
             )
     return http_routes

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -16,11 +16,12 @@ from charmlibs.interfaces.istio_ingress_route import (
     RequestRedirectFilter,
     RequestRedirectSpec,
 )
+from helpers import dict_to_httproute
 from ops import ActiveStatus, BlockedStatus
 
 from charm import IstioIngressCharm
 from tests.unit.test_gateway import generate_certificates_relation
-from utils import HTTPRoute, RouteInfo, get_unauthenticated_paths
+from utils import RouteInfo, get_unauthenticated_paths
 
 
 def create_test_http_routes(routes_info, with_tls=False):
@@ -30,74 +31,74 @@ def create_test_http_routes(routes_info, with_tls=False):
         if with_tls:
             # When TLS is enabled, HTTP route (port 80) should be a redirect
             http_routes.append(
-                HTTPRoute(
-                    name=route_info["service_name"],
-                    listener_port=80,
-                    listener_protocol="HTTP",
-                    namespace=route_info["namespace"],
-                    source_app=route_info["service_name"],
-                    source_relation="ingress",
-                    matches=[
+                dict_to_httproute({
+                    "name": route_info["service_name"],
+                    "listener_port": 80,
+                    "listener_protocol": "HTTP",
+                    "namespace": route_info["namespace"],
+                    "source_app": route_info["service_name"],
+                    "source_relation": "ingress",
+                    "matches": [
                         HTTPRouteMatch(
                             path=HTTPPathMatch(type="PathPrefix", value=route_info["prefix"])
                         )
                     ],
-                    backend_refs=[],  # Redirects don't have backends
-                    filters=[
+                    "backend_refs": [],  # Redirects don't have backends
+                    "filters": [
                         RequestRedirectFilter(
                             requestRedirect=RequestRedirectSpec(scheme="https", statusCode=301)
                         )
                     ],
-                )
+                })
             )
             # HTTPS route on port 443 with actual backend
             http_routes.append(
-                HTTPRoute(
-                    name=route_info["service_name"] + "-https",
-                    listener_port=443,
-                    listener_protocol="HTTPS",
-                    namespace=route_info["namespace"],
-                    source_app=route_info["service_name"],
-                    source_relation="ingress",
-                    matches=[
+                dict_to_httproute({
+                    "name": route_info["service_name"] + "-https",
+                    "listener_port": 443,
+                    "listener_protocol": "HTTPS",
+                    "namespace": route_info["namespace"],
+                    "source_app": route_info["service_name"],
+                    "source_relation": "ingress",
+                    "matches": [
                         HTTPRouteMatch(
                             path=HTTPPathMatch(type="PathPrefix", value=route_info["prefix"])
                         )
                     ],
-                    backend_refs=[
+                    "backend_refs": [
                         BackendRef(
                             name=route_info["service_name"],
                             port=route_info["port"],
                             namespace=route_info["namespace"],
                         )
                     ],
-                    filters=[],
-                )
+                    "filters": [],
+                })
             )
         else:
             # Without TLS, just create normal HTTP route on port 80
             http_routes.append(
-                HTTPRoute(
-                    name=route_info["service_name"],
-                    listener_port=80,
-                    listener_protocol="HTTP",
-                    namespace=route_info["namespace"],
-                    source_app=route_info["service_name"],
-                    source_relation="ingress",
-                    matches=[
+                dict_to_httproute({
+                    "name": route_info["service_name"],
+                    "listener_port": 80,
+                    "listener_protocol": "HTTP",
+                    "namespace": route_info["namespace"],
+                    "source_app": route_info["service_name"],
+                    "source_relation": "ingress",
+                    "matches": [
                         HTTPRouteMatch(
                             path=HTTPPathMatch(type="PathPrefix", value=route_info["prefix"])
                         )
                     ],
-                    backend_refs=[
+                    "backend_refs": [
                         BackendRef(
                             name=route_info["service_name"],
                             port=route_info["port"],
                             namespace=route_info["namespace"],
                         )
                     ],
-                    filters=[],
-                )
+                    "filters": [],
+                })
             )
     return http_routes
 
@@ -145,60 +146,61 @@ def test_construct_auth_policies_multi_port_aggregation(istio_ingress_charm, ist
     """Test that _construct_auth_policies aggregates multiple ports for the same backend into a single policy."""
     # Create routes that simulate the Tempo scenario: same service, different ports
     http_routes = [
-        HTTPRoute(
-            name="tempo-api",
-            listener_port=80,
-            listener_protocol="HTTP",
-            namespace="cos",
-            source_app="tempo",
-            source_relation="istio-ingress-route",
-            matches=[
+        {
+            "name": "tempo-api",
+            "listener_port": 80,
+            "listener_protocol": "HTTP",
+            "namespace": "cos",
+            "source_app": "tempo",
+            "source_relation": "istio-ingress-route",
+            "matches": [
                 HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/tempo-api"))
             ],
-            backend_refs=[BackendRef(name="tempo", port=3200, namespace="cos")],
-            filters=[],
-        ),
-        HTTPRoute(
-            name="tempo-otlp-http",
-            listener_port=80,
-            listener_protocol="HTTP",
-            namespace="cos",
-            source_app="tempo",
-            source_relation="istio-ingress-route",
-            matches=[
+            "backend_refs": [BackendRef(name="tempo", port=3200, namespace="cos")],
+            "filters": [],
+        },
+        {
+            "name": "tempo-otlp-http",
+            "listener_port": 80,
+            "listener_protocol": "HTTP",
+            "namespace": "cos",
+            "source_app": "tempo",
+            "source_relation": "istio-ingress-route",
+            "matches": [
                 HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/tempo-otlp"))
             ],
-            backend_refs=[BackendRef(name="tempo", port=4318, namespace="cos")],
-            filters=[],
-        ),
-        HTTPRoute(
-            name="tempo-zipkin",
-            listener_port=80,
-            listener_protocol="HTTP",
-            namespace="cos",
-            source_app="tempo",
-            source_relation="istio-ingress-route",
-            matches=[
+            "backend_refs": [BackendRef(name="tempo", port=4318, namespace="cos")],
+            "filters": [],
+        },
+        {
+            "name": "tempo-zipkin",
+            "listener_port": 80,
+            "listener_protocol": "HTTP",
+            "namespace": "cos",
+            "source_app": "tempo",
+            "source_relation": "istio-ingress-route",
+            "matches": [
                 HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/tempo-zipkin"))
             ],
-            backend_refs=[BackendRef(name="tempo", port=9411, namespace="cos")],
-            filters=[],
-        ),
+            "backend_refs": [BackendRef(name="tempo", port=9411, namespace="cos")],
+            "filters": [],
+        },
         # A different service in the same namespace with a single port
-        HTTPRoute(
-            name="grafana-route",
-            listener_port=80,
-            listener_protocol="HTTP",
-            namespace="cos",
-            source_app="grafana",
-            source_relation="istio-ingress-route",
-            matches=[
+        {
+            "name": "grafana-route",
+            "listener_port": 80,
+            "listener_protocol": "HTTP",
+            "namespace": "cos",
+            "source_app": "grafana",
+            "source_relation": "istio-ingress-route",
+            "matches": [
                 HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/grafana"))
             ],
-            backend_refs=[BackendRef(name="grafana", port=3000, namespace="cos")],
-            filters=[],
-        ),
+            "backend_refs": [BackendRef(name="grafana", port=3000, namespace="cos")],
+            "filters": [],
+        },
     ]
+    http_routes = [ dict_to_httproute(r) for r in http_routes ]
 
     with istio_ingress_context(
         istio_ingress_context.on.update_status(),
@@ -237,19 +239,19 @@ def test_construct_auth_policies_multi_port_aggregation(istio_ingress_charm, ist
 def test_construct_auth_policies_mixed_http_grpc(istio_ingress_charm, istio_ingress_context):
     """Test that _construct_auth_policies aggregates ports across HTTP and gRPC routes for the same backend."""
     http_routes = [
-        HTTPRoute(
-            name="myapp-http",
-            listener_port=80,
-            listener_protocol="HTTP",
-            namespace="test-ns",
-            source_app="myapp",
-            source_relation="istio-ingress-route",
-            matches=[
+        dict_to_httproute({
+            "name": "myapp-http",
+            "listener_port": 80,
+            "listener_protocol": "HTTP",
+            "namespace": "test-ns",
+            "source_app": "myapp",
+            "source_relation": "istio-ingress-route",
+            "matches": [
                 HTTPRouteMatch(path=HTTPPathMatch(type="PathPrefix", value="/myapp"))
             ],
-            backend_refs=[BackendRef(name="myapp", port=8080, namespace="test-ns")],
-            filters=[],
-        ),
+            "backend_refs": [BackendRef(name="myapp", port=8080, namespace="test-ns")],
+            "filters": [],
+        }),
     ]
     grpc_routes = [
         {

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -16,7 +16,7 @@ from charmlibs.interfaces.istio_ingress_route import (
     RequestRedirectFilter,
     RequestRedirectSpec,
 )
-from helpers import dict_to_httproute
+from helpers import dict_to_grpcroute, dict_to_httproute
 from ops import ActiveStatus, BlockedStatus
 
 from charm import IstioIngressCharm
@@ -254,7 +254,7 @@ def test_construct_auth_policies_mixed_http_grpc(istio_ingress_charm, istio_ingr
         }),
     ]
     grpc_routes = [
-        {
+        dict_to_grpcroute({
             "name": "myapp-grpc",
             "listener_port": 9000,
             "listener_protocol": "HTTP",
@@ -266,7 +266,7 @@ def test_construct_auth_policies_mixed_http_grpc(istio_ingress_charm, istio_ingr
             ],
             "backend_refs": [BackendRef(name="myapp", port=9000, namespace="test-ns")],
             "filters": [],
-        },
+        }),
     ]
 
     with istio_ingress_context(
@@ -768,6 +768,7 @@ def test_construct_grpc_destination_rules(istio_ingress_charm, istio_ingress_con
             "filters": [],
         },
     ]
+    grpc_routes = [ dict_to_grpcroute(r) for r in grpc_routes ]
 
     with patch.object(IstioIngressCharm, "_is_ready"), istio_ingress_context(
         istio_ingress_context.on.update_status(),

--- a/tests/unit/test_upstream_ingress.py
+++ b/tests/unit/test_upstream_ingress.py
@@ -9,6 +9,11 @@ import pytest
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from ops.testing import Harness
 
+from canonical_service_mesh.models import (
+    AllowedRoutes, 
+    Listener,
+)
+
 from charm import IstioIngressCharm
 
 
@@ -75,6 +80,6 @@ def test_construct_gateway_uses_local_address_not_upstream(harness):
     ), patch.object(
         IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
     ):
-        listeners = [{"port": 80, "gateway_protocol": "HTTP", "tls_secret_name": None, "source_app": "test"}]
+        listeners = [Listener(name="",port=80,protocol="HTTP",allowedRoutes=AllowedRoutes(namespaces={}),tls=None)]
         gateway = charm._construct_gateway(listeners)
         assert gateway.spec["listeners"][0]["hostname"] == "local.example.com"

--- a/tests/unit/test_upstream_ingress.py
+++ b/tests/unit/test_upstream_ingress.py
@@ -6,13 +6,12 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
-from ops.testing import Harness
-
 from canonical_service_mesh.models import (
-    AllowedRoutes, 
+    AllowedRoutes,
     Listener,
 )
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from ops.testing import Harness
 
 from charm import IstioIngressCharm
 

--- a/tests/unit/test_upstream_ingress.py
+++ b/tests/unit/test_upstream_ingress.py
@@ -6,9 +6,31 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-from canonical_service_mesh.models import (
-    AllowedRoutes,
-    Listener,
+from charmlibs.interfaces.istio_ingress_route import (
+    BackendRef as LibBackendRef,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    GRPCMethodMatch,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    GRPCRoute as LibGRPCRoute,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    GRPCRouteMatch as LibGRPCRouteMatch,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    HTTPPathMatch as LibHTTPPathMatch,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    HTTPRoute as LibHTTPRoute,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    HTTPRouteMatch as LibHTTPRouteMatch,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    Listener as LibListener,
 )
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from ops.testing import Harness
@@ -73,12 +95,44 @@ def test_construct_gateway_uses_local_address_not_upstream(harness):
     harness.update_config({"external_hostname": "local.example.com"})
     harness.begin()
     charm = harness.charm
+    http_listener = LibListener(port=8080, protocol=ProtocolType.HTTP)
+    grpc_listener = LibListener(port=9090, protocol=ProtocolType.GRPC)
+
+    istio_ingress_route_configs = {
+        ("app1", "istio-ingress-route"): {
+            "config": IstioIngressRouteConfig(
+                model="model1",
+                listeners=[http_listener, grpc_listener],
+                http_routes=[
+                    LibHTTPRoute(
+                        name="http-route",
+                        listener=http_listener,
+                        backends=[LibBackendRef(service="svc", port=80)],
+                        matches=[
+                            LibHTTPRouteMatch(
+                                path=LibHTTPPathMatch(type="PathPrefix", value="/api")
+                            )
+                        ],
+                    )
+                ],
+                grpc_routes=[
+                    LibGRPCRoute(
+                        name="grpc-route",
+                        listener=grpc_listener,
+                        backends=[LibBackendRef(service="grpc-svc", port=9000)],
+                        matches=[LibGRPCRouteMatch(method=GRPCMethodMatch(service="MyService"))],
+                    )
+                ],
+            )
+        }
+    }
 
     with patch.object(
         charm.upstream_ingress, "is_ready", return_value=True
     ), patch.object(
         IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
     ):
-        listeners = [Listener(name="",port=80,protocol="HTTP",allowedRoutes=AllowedRoutes(namespaces={}),tls=None)]
-        gateway = charm._construct_gateway(listeners)
-        assert gateway.spec["listeners"][0]["hostname"] == "local.example.com"
+        ipa_routes, istio_ingress_routes = charm._get_all_listeners("my-tls-secret",istio_ingress_route_configs)
+        gateway = charm._construct_gateway(ipa_routes + istio_ingress_routes)
+        for gw in gateway.spec["listeners"]:
+            assert gw["hostname"] == "local.example.com"

--- a/tests/unit/test_utils_deduplication.py
+++ b/tests/unit/test_utils_deduplication.py
@@ -131,7 +131,7 @@ def test_deduplicate_http_routes_with_conflicts():
 
     # Only route3 (/users) should remain
     assert len(valid_routes) == 1
-    assert valid_routes[0].resource.spec.rules[0].matches[0].path.value == "/users"
+    assert valid_routes[0].spec.rules[0].matches[0].path.value == "/users"
 
 
 def test_deduplicate_grpc_routes_no_conflicts():
@@ -223,7 +223,7 @@ def test_deduplicate_grpc_routes_with_conflicts():
 
     # Only route3 (OrderService) should remain
     assert len(valid_routes) == 1
-    assert valid_routes[0].resource.spec.rules[0].matches[0].method.service == "OrderService"
+    assert valid_routes[0].spec.rules[0].matches[0].method.service == "OrderService"
 
 
 def test_clear_conflicting_routes():

--- a/tests/unit/test_utils_deduplication.py
+++ b/tests/unit/test_utils_deduplication.py
@@ -27,7 +27,7 @@ from charmlibs.interfaces.istio_ingress_route import (
     Listener,
     ProtocolType,
 )
-from helpers import dict_to_httproute
+from helpers import dict_to_grpcroute, dict_to_httproute
 
 from utils import (
     clear_conflicting_routes,
@@ -162,6 +162,7 @@ def test_deduplicate_grpc_routes_no_conflicts():
             "backend_refs": [BackendRef(name="grpc-svc2", port=9000, namespace="model2")],
         },
     ]
+    all_grpc_routes = [ dict_to_grpcroute(r) for r in all_grpc_routes ]
 
     valid_routes, apps_to_clear = deduplicate_grpc_routes(all_grpc_routes)
 
@@ -210,6 +211,7 @@ def test_deduplicate_grpc_routes_with_conflicts():
             "backend_refs": [BackendRef(name="grpc-svc3", port=9000, namespace="model3")],
         },
     ]
+    all_grpc_routes = [ dict_to_grpcroute(r) for r in all_grpc_routes ]
 
     valid_routes, apps_to_clear = deduplicate_grpc_routes(all_grpc_routes)
 
@@ -221,7 +223,7 @@ def test_deduplicate_grpc_routes_with_conflicts():
 
     # Only route3 (OrderService) should remain
     assert len(valid_routes) == 1
-    assert valid_routes[0]["matches"][0].method.service == "OrderService"
+    assert valid_routes[0].resource.spec.rules[0].matches[0].method.service == "OrderService"
 
 
 def test_clear_conflicting_routes():

--- a/tests/unit/test_utils_deduplication.py
+++ b/tests/unit/test_utils_deduplication.py
@@ -27,8 +27,13 @@ from charmlibs.interfaces.istio_ingress_route import (
     Listener,
     ProtocolType,
 )
+from helpers import dict_to_httproute
 
-from utils import clear_conflicting_routes, deduplicate_grpc_routes, deduplicate_http_routes
+from utils import (
+    clear_conflicting_routes,
+    deduplicate_grpc_routes,
+    deduplicate_http_routes,
+)
 
 
 def test_deduplicate_http_routes_no_conflicts():
@@ -68,6 +73,7 @@ def test_deduplicate_http_routes_no_conflicts():
             "filters": [],
         },
     ]
+    all_http_routes = [ dict_to_httproute(d) for d in all_http_routes ]
 
     valid_routes, apps_to_clear = deduplicate_http_routes(all_http_routes)
 
@@ -114,6 +120,7 @@ def test_deduplicate_http_routes_with_conflicts():
         },
     ]
 
+    all_http_routes = [ dict_to_httproute(d) for d in all_http_routes ]
     valid_routes, apps_to_clear = deduplicate_http_routes(all_http_routes)
 
     # Conflict: app1 and app2 both want /api on HTTP:80
@@ -124,7 +131,7 @@ def test_deduplicate_http_routes_with_conflicts():
 
     # Only route3 (/users) should remain
     assert len(valid_routes) == 1
-    assert valid_routes[0]["matches"][0].path.value == "/users"
+    assert valid_routes[0].resource.spec.rules[0].matches[0].path.value == "/users"
 
 
 def test_deduplicate_grpc_routes_no_conflicts():

--- a/tests/unit/test_utils_normalization.py
+++ b/tests/unit/test_utils_normalization.py
@@ -222,11 +222,12 @@ def test_normalize_ipa_routes_with_strip_prefix():
 
     assert len(http_routes) == 1
     route = http_routes[0]
-    assert route["name"] == "svc1-httproute-http-80-istio-ingress-k8s"  # Name format: {service}-httproute-{section_name}-{ingress_app_name}
-    assert route["listener_port"] == 80
-    assert route["listener_protocol"] == "HTTP"
-    assert len(route["filters"]) == 1
-    assert route["filters"][0].type == FilterType.URLRewrite
+    assert route.resource.metadata.name == "svc1-httproute-http-80-istio-ingress-k8s"  # Name format: {service}-httproute-{section_name}-{ingress_app_name}
+    assert route.listener_port == 80
+    assert route.listener_protocol == "HTTP"
+    filters = route.resource.spec.rules[0].filters
+    assert len(filters) == 1
+    assert filters[0].type == FilterType.URLRewrite
 
 
 def test_normalize_ipa_routes_with_tls_creates_redirect():
@@ -254,26 +255,31 @@ def test_normalize_ipa_routes_with_tls_creates_redirect():
 
     # First route should be HTTP redirect
     redirect_route = http_routes[0]
-    assert redirect_route["name"] == "svc1-httproute-http-80-istio-ingress-k8s"
-    assert redirect_route["listener_port"] == 80
-    assert redirect_route["listener_protocol"] == "HTTP"
-    assert len(redirect_route["backend_refs"]) == 0  # No backends for redirect
-    assert len(redirect_route["filters"]) == 1
-    assert redirect_route["filters"][0].type == FilterType.RequestRedirect
-    assert redirect_route["filters"][0].requestRedirect.scheme == "https"
-    assert redirect_route["filters"][0].requestRedirect.statusCode == 301
+    assert redirect_route.resource.metadata.name == "svc1-httproute-http-80-istio-ingress-k8s"
+    assert redirect_route.listener_port == 80
+    assert redirect_route.listener_protocol == "HTTP"
+    assert len(redirect_route.resource.spec.rules[0].backendRefs) == 0  # No backends for redirect
+
+    filters = redirect_route.resource.spec.rules[0].filters
+    assert len(filters) == 1
+    assert filters[0].type == FilterType.RequestRedirect
+    assert filters[0].requestRedirect.scheme == "https"
+    assert filters[0].requestRedirect.statusCode == 301
 
     # Second route should be HTTPS with backends
     https_route = http_routes[1]
-    assert https_route["name"] == "svc1-httproute-https-443-istio-ingress-k8s"
-    assert https_route["listener_port"] == 443
-    assert https_route["listener_protocol"] == "HTTPS"
-    assert len(https_route["backend_refs"]) == 1
-    assert https_route["backend_refs"][0].name == "svc1"
-    assert https_route["backend_refs"][0].port == 8080
+    assert https_route.resource.metadata.name == "svc1-httproute-https-443-istio-ingress-k8s"
+    assert https_route.listener_port == 443
+    assert https_route.listener_protocol == "HTTPS"
+
+    backed_refs = https_route.resource.spec.rules[0].backendRefs
+    assert len(backed_refs) == 1
+    assert backed_refs[0].name == "svc1"
+    assert backed_refs[0].port == 8080
     # Should have URLRewrite filter because strip_prefix=True
-    assert len(https_route["filters"]) == 1
-    assert https_route["filters"][0].type == FilterType.URLRewrite
+    filters = https_route.resource.spec.rules[0].filters
+    assert len(filters) == 1
+    assert filters[0].type == FilterType.URLRewrite
 
 
 def test_normalize_istio_ingress_route_http_and_grpc_routes():
@@ -322,10 +328,10 @@ def test_normalize_istio_ingress_route_http_and_grpc_routes():
     # Verify HTTP route conversion
     assert len(http_routes) == 1
     http_route = http_routes[0]
-    assert http_route["name"] == "app1-http-route-httproute-http-8080-istio-ingress-k8s"  # Route name format: {app}-{route.name}-httproute-{section_name}-{ingress_app_name}
-    assert http_route["listener_port"] == 8080
-    assert http_route["source_relation"] == "istio-ingress-route"
-    assert len(http_route["matches"]) == 1
+    assert http_route.resource.metadata.name == "app1-http-route-httproute-http-8080-istio-ingress-k8s"  # Route name format: {app}-{route.name}-httproute-{section_name}-{ingress_app_name}
+    assert http_route.listener_port == 8080
+    assert http_route.source_relation == "istio-ingress-route"
+    assert len(http_route.resource.spec.rules[0].matches) == 1
 
     # Verify gRPC route conversion
     assert len(grpc_routes) == 1

--- a/tests/unit/test_utils_normalization.py
+++ b/tests/unit/test_utils_normalization.py
@@ -336,10 +336,10 @@ def test_normalize_istio_ingress_route_http_and_grpc_routes():
     # Verify gRPC route conversion
     assert len(grpc_routes) == 1
     grpc_route = grpc_routes[0]
-    assert grpc_route["name"] == "app1-grpc-route-grpcroute-http-9090-istio-ingress-k8s"  # Route name format: {app}-{route.name}-grpcroute-{section_name}-{ingress_app_name}
-    assert grpc_route["listener_port"] == 9090
-    assert grpc_route["source_relation"] == "istio-ingress-route"
-    assert len(grpc_route["matches"]) == 1
+    assert grpc_route.resource.metadata.name == "app1-grpc-route-grpcroute-http-9090-istio-ingress-k8s"  # Route name format: {app}-{route.name}-grpcroute-{section_name}-{ingress_app_name}
+    assert grpc_route.listener_port == 9090
+    assert grpc_route.source_relation == "istio-ingress-route"
+    assert len(grpc_route.resource.spec.rules[0].matches) == 1
 
 
 def test_get_unauthenticated_paths():

--- a/tests/unit/test_utils_normalization.py
+++ b/tests/unit/test_utils_normalization.py
@@ -38,6 +38,9 @@ from charmlibs.interfaces.istio_ingress_route import (
 from utils import (
     create_gateway_tls_config,
     deduplicate_listeners,
+    get_listener_port_from_label,
+    get_listener_protocol_from_label,
+    get_requesting_app_and_relation_forom_label,
     get_unauthenticated_paths,
     get_unauthenticated_paths_from_istio_ingress_route_configs,
     normalize_ipa_listeners,
@@ -52,7 +55,7 @@ def test_normalize_ipa_listeners_without_tls():
     """Test normalizing IPA listeners without TLS creates single HTTP listener."""
     tls_secret_name = None
 
-    listeners = normalize_ipa_listeners(tls_secret_name)
+    listeners = normalize_ipa_listeners(tls_secret_name,hostname="example.com")
 
     assert len(listeners) == 1
     assert listeners[0].port == 80
@@ -64,7 +67,7 @@ def test_normalize_ipa_listeners_with_tls():
     """Test normalizing IPA listeners with TLS creates HTTP and HTTPS listeners."""
     tls_secret_name = "my-tls-secret"
 
-    listeners = normalize_ipa_listeners(tls_secret_name)
+    listeners = normalize_ipa_listeners(tls_secret_name,hostname="example.com")
 
     assert len(listeners) == 2
     http_listener = [listener for listener in listeners if listener.port == 80][0]
@@ -114,7 +117,7 @@ def test_normalize_istio_ingress_route_listeners_without_tls():
     tls_secret_name = None
 
     listeners = normalize_istio_ingress_route_listeners(
-        istio_ingress_route_configs, tls_secret_name
+        istio_ingress_route_configs, tls_secret_name, hostname="example.com"
     )
 
     assert len(listeners) == 2
@@ -163,7 +166,7 @@ def test_normalize_istio_ingress_route_listeners_with_tls():
     tls_secret_name = "my-tls-secret"
 
     listeners = normalize_istio_ingress_route_listeners(
-        istio_ingress_route_configs, tls_secret_name
+        istio_ingress_route_configs, tls_secret_name, hostname="example.com"
     )
 
     # Should have 2 listeners converted to HTTPS: 8080 HTTPS, 9090 HTTPS
@@ -218,14 +221,14 @@ def test_normalize_ipa_routes_with_strip_prefix():
     is_tls_enabled = False
     ingress_app_name = "istio-ingress-k8s"
 
-    http_routes = normalize_ipa_routes(ipa_relations, is_tls_enabled, ingress_app_name)
+    http_routes = normalize_ipa_routes(ipa_relations, is_tls_enabled, ingress_app_name, ingress_model_name="xyz")
 
     assert len(http_routes) == 1
     route = http_routes[0]
-    assert route.resource.metadata.name == "svc1-httproute-http-80-istio-ingress-k8s"  # Name format: {service}-httproute-{section_name}-{ingress_app_name}
-    assert route.listener_port == 80
-    assert route.listener_protocol == "HTTP"
-    filters = route.resource.spec.rules[0].filters
+    assert route.metadata.name == "svc1-httproute-http-80-istio-ingress-k8s"  # Name format: {service}-httproute-{section_name}-{ingress_app_name}
+    assert get_listener_port_from_label(route.metadata) == 80
+    assert get_listener_protocol_from_label(route.metadata) == "HTTP"
+    filters = route.spec.rules[0].filters
     assert len(filters) == 1
     assert filters[0].type == FilterType.URLRewrite
 
@@ -248,19 +251,19 @@ def test_normalize_ipa_routes_with_tls_creates_redirect():
     is_tls_enabled = True
     ingress_app_name = "istio-ingress-k8s"
 
-    http_routes = normalize_ipa_routes(ipa_relations, is_tls_enabled, ingress_app_name)
+    http_routes = normalize_ipa_routes(ipa_relations, is_tls_enabled, ingress_app_name, ingress_model_name="xyz")
 
     # Should create 2 routes: HTTP redirect + HTTPS actual
     assert len(http_routes) == 2
 
     # First route should be HTTP redirect
     redirect_route = http_routes[0]
-    assert redirect_route.resource.metadata.name == "svc1-httproute-http-80-istio-ingress-k8s"
-    assert redirect_route.listener_port == 80
-    assert redirect_route.listener_protocol == "HTTP"
-    assert len(redirect_route.resource.spec.rules[0].backendRefs) == 0  # No backends for redirect
+    assert redirect_route.metadata.name == "svc1-httproute-http-80-istio-ingress-k8s"
+    assert get_listener_port_from_label(redirect_route.metadata) == 80
+    assert get_listener_protocol_from_label(redirect_route.metadata) == "HTTP"
+    assert len(redirect_route.spec.rules[0].backendRefs) == 0  # No backends for redirect
 
-    filters = redirect_route.resource.spec.rules[0].filters
+    filters = redirect_route.spec.rules[0].filters
     assert len(filters) == 1
     assert filters[0].type == FilterType.RequestRedirect
     assert filters[0].requestRedirect.scheme == "https"
@@ -268,16 +271,16 @@ def test_normalize_ipa_routes_with_tls_creates_redirect():
 
     # Second route should be HTTPS with backends
     https_route = http_routes[1]
-    assert https_route.resource.metadata.name == "svc1-httproute-https-443-istio-ingress-k8s"
-    assert https_route.listener_port == 443
-    assert https_route.listener_protocol == "HTTPS"
+    assert https_route.metadata.name == "svc1-httproute-https-443-istio-ingress-k8s"
+    assert get_listener_port_from_label(https_route.metadata) == 443
+    assert get_listener_protocol_from_label(https_route.metadata) == "HTTPS"
 
-    backed_refs = https_route.resource.spec.rules[0].backendRefs
+    backed_refs = https_route.spec.rules[0].backendRefs
     assert len(backed_refs) == 1
     assert backed_refs[0].name == "svc1"
     assert backed_refs[0].port == 8080
     # Should have URLRewrite filter because strip_prefix=True
-    filters = https_route.resource.spec.rules[0].filters
+    filters = https_route.spec.rules[0].filters
     assert len(filters) == 1
     assert filters[0].type == FilterType.URLRewrite
 
@@ -319,27 +322,27 @@ def test_normalize_istio_ingress_route_http_and_grpc_routes():
     ingress_app_name = "istio-ingress-k8s"
 
     http_routes = normalize_istio_ingress_route_http_routes(
-        istio_ingress_route_configs, is_tls_enabled, ingress_app_name
+        istio_ingress_route_configs, is_tls_enabled, ingress_app_name, ingress_model_name="xyz"
     )
     grpc_routes = normalize_istio_ingress_route_grpc_routes(
-        istio_ingress_route_configs, is_tls_enabled, ingress_app_name
+        istio_ingress_route_configs, is_tls_enabled, ingress_app_name, ingress_model_name="xyz"
     )
 
     # Verify HTTP route conversion
     assert len(http_routes) == 1
     http_route = http_routes[0]
-    assert http_route.resource.metadata.name == "app1-http-route-httproute-http-8080-istio-ingress-k8s"  # Route name format: {app}-{route.name}-httproute-{section_name}-{ingress_app_name}
-    assert http_route.listener_port == 8080
-    assert http_route.source_relation == "istio-ingress-route"
-    assert len(http_route.resource.spec.rules[0].matches) == 1
+    assert http_route.metadata.name == "app1-http-route-httproute-http-8080-istio-ingress-k8s"  # Route name format: {app}-{route.name}-httproute-{section_name}-{ingress_app_name}
+    assert get_listener_port_from_label(http_route.metadata) == 8080
+    assert get_requesting_app_and_relation_forom_label(http_route.metadata)[1] == "istio-ingress-route"
+    assert len(http_route.spec.rules[0].matches) == 1
 
     # Verify gRPC route conversion
     assert len(grpc_routes) == 1
     grpc_route = grpc_routes[0]
-    assert grpc_route.resource.metadata.name == "app1-grpc-route-grpcroute-http-9090-istio-ingress-k8s"  # Route name format: {app}-{route.name}-grpcroute-{section_name}-{ingress_app_name}
-    assert grpc_route.listener_port == 9090
-    assert grpc_route.source_relation == "istio-ingress-route"
-    assert len(grpc_route.resource.spec.rules[0].matches) == 1
+    assert grpc_route.metadata.name == "app1-grpc-route-grpcroute-http-9090-istio-ingress-k8s"  # Route name format: {app}-{route.name}-grpcroute-{section_name}-{ingress_app_name}
+    assert get_listener_port_from_label(grpc_route.metadata) == 9090
+    assert get_requesting_app_and_relation_forom_label(grpc_route.metadata)[1] == "istio-ingress-route"
+    assert len(grpc_route.spec.rules[0].matches) == 1
 
 
 def test_get_unauthenticated_paths():

--- a/tests/unit/test_utils_normalization.py
+++ b/tests/unit/test_utils_normalization.py
@@ -3,6 +3,13 @@
 
 """Tests for utils.py normalization functions."""
 
+from canonical_service_mesh.models import (
+    AllowedRoutes,
+    Listener,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    BackendRef as LibBackendRef,
+)
 from charmlibs.interfaces.istio_ingress_route import (
     FilterType,
     GRPCMethodMatch,
@@ -10,18 +17,22 @@ from charmlibs.interfaces.istio_ingress_route import (
     ProtocolType,
 )
 from charmlibs.interfaces.istio_ingress_route import (
-    BackendRef as LibBackendRef,
     GRPCRoute as LibGRPCRoute,
-    GRPCRouteMatch as LibGRPCRouteMatch,
-    HTTPPathMatch as LibHTTPPathMatch,
-    HTTPRoute as LibHTTPRoute,
-    HTTPRouteMatch as LibHTTPRouteMatch,
-    Listener as LibListener,
 )
-
-from canonical_service_mesh.models import (
-    AllowedRoutes, 
-    Listener,
+from charmlibs.interfaces.istio_ingress_route import (
+    GRPCRouteMatch as LibGRPCRouteMatch,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    HTTPPathMatch as LibHTTPPathMatch,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    HTTPRoute as LibHTTPRoute,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    HTTPRouteMatch as LibHTTPRouteMatch,
+)
+from charmlibs.interfaces.istio_ingress_route import (
+    Listener as LibListener,
 )
 
 from utils import (
@@ -164,7 +175,7 @@ def test_normalize_istio_ingress_route_listeners_with_tls():
     assert https_8080.protocol == "HTTPS"
     assert https_8080.tls is not None
     assert https_8080.tls.certificateRefs[0].name == "my-tls-secret"
-    
+
     assert https_9090.protocol == "HTTPS"
     assert https_9090.tls is not None
     assert https_9090.tls.certificateRefs[0].name == "my-tls-secret"

--- a/tests/unit/test_utils_normalization.py
+++ b/tests/unit/test_utils_normalization.py
@@ -4,32 +4,28 @@
 """Tests for utils.py normalization functions."""
 
 from charmlibs.interfaces.istio_ingress_route import (
-    BackendRef as LibBackendRef,
-)
-from charmlibs.interfaces.istio_ingress_route import (
     FilterType,
     GRPCMethodMatch,
     IstioIngressRouteConfig,
-    Listener,
     ProtocolType,
 )
 from charmlibs.interfaces.istio_ingress_route import (
+    BackendRef as LibBackendRef,
     GRPCRoute as LibGRPCRoute,
-)
-from charmlibs.interfaces.istio_ingress_route import (
     GRPCRouteMatch as LibGRPCRouteMatch,
-)
-from charmlibs.interfaces.istio_ingress_route import (
     HTTPPathMatch as LibHTTPPathMatch,
-)
-from charmlibs.interfaces.istio_ingress_route import (
     HTTPRoute as LibHTTPRoute,
-)
-from charmlibs.interfaces.istio_ingress_route import (
     HTTPRouteMatch as LibHTTPRouteMatch,
+    Listener as LibListener,
+)
+
+from canonical_service_mesh.models import (
+    AllowedRoutes, 
+    Listener,
 )
 
 from utils import (
+    create_gateway_tls_config,
     deduplicate_listeners,
     get_unauthenticated_paths,
     get_unauthenticated_paths_from_istio_ingress_route_configs,
@@ -48,10 +44,9 @@ def test_normalize_ipa_listeners_without_tls():
     listeners = normalize_ipa_listeners(tls_secret_name)
 
     assert len(listeners) == 1
-    assert listeners[0]["port"] == 80
-    assert listeners[0]["gateway_protocol"] == "HTTP"
-    assert listeners[0]["tls_secret_name"] is None
-    assert listeners[0]["source_app"] == "ipa"
+    assert listeners[0].port == 80
+    assert listeners[0].protocol == "HTTP"
+    assert listeners[0].tls is None
 
 
 def test_normalize_ipa_listeners_with_tls():
@@ -61,20 +56,21 @@ def test_normalize_ipa_listeners_with_tls():
     listeners = normalize_ipa_listeners(tls_secret_name)
 
     assert len(listeners) == 2
-    http_listener = [listener for listener in listeners if listener["port"] == 80][0]
-    https_listener = [listener for listener in listeners if listener["port"] == 443][0]
+    http_listener = [listener for listener in listeners if listener.port == 80][0]
+    https_listener = [listener for listener in listeners if listener.port == 443][0]
 
-    assert http_listener["gateway_protocol"] == "HTTP"
-    assert http_listener["tls_secret_name"] is None
+    assert http_listener.protocol == "HTTP"
+    assert http_listener.tls is None
 
-    assert https_listener["gateway_protocol"] == "HTTPS"
-    assert https_listener["tls_secret_name"] == "my-tls-secret"
+    assert https_listener.protocol == "HTTPS"
+    assert https_listener.tls is not None
+    assert https_listener.tls.certificateRefs[0].name == "my-tls-secret"
 
 
 def test_normalize_istio_ingress_route_listeners_without_tls():
     """Test normalizing istio-ingress-route listeners without TLS for HTTP and gRPC."""
-    http_listener = Listener(port=8080, protocol=ProtocolType.HTTP)
-    grpc_listener = Listener(port=9090, protocol=ProtocolType.GRPC)
+    http_listener = LibListener(port=8080, protocol=ProtocolType.HTTP)
+    grpc_listener = LibListener(port=9090, protocol=ProtocolType.GRPC)
 
     istio_ingress_route_configs = {
         ("app1", "istio-ingress-route"): {
@@ -111,19 +107,19 @@ def test_normalize_istio_ingress_route_listeners_without_tls():
     )
 
     assert len(listeners) == 2
-    http_listener_norm = [listener for listener in listeners if listener["port"] == 8080][0]
-    grpc_listener_norm = [listener for listener in listeners if listener["port"] == 9090][0]
+    http_listener_norm = [listener for listener in listeners if listener.port == 8080][0]
+    grpc_listener_norm = [listener for listener in listeners if listener.port == 9090][0]
 
-    assert http_listener_norm["gateway_protocol"] == "HTTP"
-    assert http_listener_norm["tls_secret_name"] is None
-    assert grpc_listener_norm["gateway_protocol"] == "HTTP"
-    assert grpc_listener_norm["tls_secret_name"] is None
+    assert http_listener_norm.protocol == "HTTP"
+    assert http_listener_norm.tls is None
+    assert grpc_listener_norm.protocol == "HTTP"
+    assert grpc_listener_norm.tls is None
 
 
 def test_normalize_istio_ingress_route_listeners_with_tls():
     """Test normalizing istio-ingress-route listeners with TLS converts to HTTPS."""
-    http_listener = Listener(port=8080, protocol=ProtocolType.HTTP)
-    grpc_listener = Listener(port=9090, protocol=ProtocolType.GRPC)
+    http_listener = LibListener(port=8080, protocol=ProtocolType.HTTP)
+    grpc_listener = LibListener(port=9090, protocol=ProtocolType.GRPC)
 
     istio_ingress_route_configs = {
         ("app1", "istio-ingress-route"): {
@@ -162,39 +158,35 @@ def test_normalize_istio_ingress_route_listeners_with_tls():
     # Should have 2 listeners converted to HTTPS: 8080 HTTPS, 9090 HTTPS
     assert len(listeners) == 2
 
-    https_8080 = [listener for listener in listeners if listener["port"] == 8080][0]
-    https_9090 = [listener for listener in listeners if listener["port"] == 9090][0]
+    https_8080 = [listener for listener in listeners if listener.port == 8080][0]
+    https_9090 = [listener for listener in listeners if listener.port == 9090][0]
 
-    assert https_8080["gateway_protocol"] == "HTTPS"
-    assert https_8080["tls_secret_name"] == "my-tls-secret"
-    assert https_9090["gateway_protocol"] == "HTTPS"
-    assert https_9090["tls_secret_name"] == "my-tls-secret"
+    assert https_8080.protocol == "HTTPS"
+    assert https_8080.tls is not None
+    assert https_8080.tls.certificateRefs[0].name == "my-tls-secret"
+    
+    assert https_9090.protocol == "HTTPS"
+    assert https_9090.tls is not None
+    assert https_9090.tls.certificateRefs[0].name == "my-tls-secret"
 
 
 def test_merge_listeners_with_duplicates():
     """Test merging listeners keeps first occurrence for each port/protocol."""
-    listeners = [
-        {"port": 80, "gateway_protocol": "HTTP", "tls_secret_name": None, "source_app": "app1"},
-        {"port": 80, "gateway_protocol": "HTTP", "tls_secret_name": None, "source_app": "app2"},
-        {
-            "port": 443,
-            "gateway_protocol": "HTTPS",
-            "tls_secret_name": "tls",
-            "source_app": "app1",
-        },
-    ]
+    l1 = Listener(name="app1",port=80,protocol="HTTP",allowedRoutes=AllowedRoutes(namespaces={}),tls=None)
+    l2 = Listener(name="app2",port=80,protocol="HTTP",allowedRoutes=AllowedRoutes(namespaces={}),tls=None)
+    l3 = Listener(name="app1",port=443,protocol="HTTPS",allowedRoutes=AllowedRoutes(namespaces={}),tls=create_gateway_tls_config("tls"))
 
-    merged = deduplicate_listeners(listeners)
+    merged = deduplicate_listeners([l1,l2,l3])
 
     # Should deduplicate port 80 HTTP to a single listener (first one)
     assert len(merged) == 2
-    assert merged[0]["port"] == 80
-    assert merged[0]["gateway_protocol"] == "HTTP"
-    assert merged[0]["source_app"] == "app1"  # First occurrence wins
+    assert merged[0].port == 80
+    assert merged[0].protocol == "HTTP"
+    assert merged[0].name == "app1"  # First occurrence wins
 
-    assert merged[1]["port"] == 443
-    assert merged[1]["gateway_protocol"] == "HTTPS"
-    assert merged[1]["source_app"] == "app1"
+    assert merged[1].port == 443
+    assert merged[1].protocol == "HTTPS"
+    assert merged[1].name == "app1"
 
 
 def test_normalize_ipa_routes_with_strip_prefix():
@@ -275,8 +267,8 @@ def test_normalize_ipa_routes_with_tls_creates_redirect():
 
 def test_normalize_istio_ingress_route_http_and_grpc_routes():
     """Test normalizing istio-ingress-route converts library models to charm models."""
-    http_listener = Listener(port=8080, protocol=ProtocolType.HTTP)
-    grpc_listener = Listener(port=9090, protocol=ProtocolType.GRPC)
+    http_listener = LibListener(port=8080, protocol=ProtocolType.HTTP)
+    grpc_listener = LibListener(port=9090, protocol=ProtocolType.GRPC)
 
     istio_ingress_route_configs = {
         ("app1", "istio-ingress-route"): {
@@ -350,8 +342,8 @@ def test_get_unauthenticated_paths():
 
 def test_get_unauthenticated_paths_from_istio_ingress_route():
     """Test extracting unauthenticated paths from istio-ingress-route for HTTP and gRPC."""
-    http_listener = Listener(port=8080, protocol=ProtocolType.HTTP)
-    grpc_listener = Listener(port=9090, protocol=ProtocolType.GRPC)
+    http_listener = LibListener(port=8080, protocol=ProtocolType.HTTP)
+    grpc_listener = LibListener(port=9090, protocol=ProtocolType.GRPC)
 
     istio_ingress_route_configs = {
         ("app1", "istio-ingress-route-unauthenticated"): {


### PR DESCRIPTION
Closes #118 

This PR aims to use the final k8s objects during normalization and deduplication. `GatewayListener` was removable because it was a flat version of the k8s object. However, `HTTPRoute` and `GRPCRoute` contained more information than their k8s counterpart. Thus, they cannot be fully eliminated. Moreover, `GRPCRoute` and `HTTPRoute` introduced some `route.something.somethingelse.thisiswahtineed` patterns. 

(I am OK with keeping only the first two commits. Then, `charm.py` can be simplified by extracting the creation of those nested k8s `...Resource` objects into their own functions.) 